### PR TITLE
strtok fix for alternating delimiters

### DIFF
--- a/stdlib/env.c
+++ b/stdlib/env.c
@@ -102,10 +102,17 @@ static int _env_insert(int idx, char *v, unsigned allocated)
 			memset(new_environ + _size, 0, sizeof(char*) * (new_size - _size));
 
 			environ = new_environ;
-			_size = new_size;
 
-			if (_string_allocated)
-				_string_allocated = realloc(_string_allocated, sizeof(unsigned) * new_size);
+			if (_string_allocated) {
+				unsigned * ptr = realloc(_string_allocated, sizeof(unsigned) * new_size);
+				if (!ptr) {
+					errno = ENOMEM;
+					return -1;
+				}
+				_string_allocated = ptr;
+			}
+
+			_size = new_size;
 		}
 
 		idx = cnt++;

--- a/string/string.c
+++ b/string/string.c
@@ -367,19 +367,23 @@ char *strtok(char *s1, const char *s2)
 {
 	char *tokend;
 
-	if (s1 != NULL)
-		s1 += strspn(s1, s2);
-	else
+	if (s1 == NULL)
 		s1 = string_common.next_token;
+	s1 += strspn(s1, s2);
 
-	if (!*s1)
+	if (!*s1) {
+		string_common.next_token = s1;
 		return NULL;
+	}
 
 	tokend = s1 + strcspn(s1, s2);
 
-	string_common.next_token = tokend + strspn(tokend, s2);
-
-	*tokend = 0;
+	if (*tokend) {
+		*tokend = 0;
+		string_common.next_token = tokend + 1;
+	} else {
+		string_common.next_token = tokend;
+	}
 
 	return s1;
 }

--- a/string/string.c
+++ b/string/string.c
@@ -388,14 +388,13 @@ char *strtok(char *s1, const char *s2)
 char *strsep(char **string_ptr, const char *delimiter)
 {
 	char *ret = (*string_ptr);
-	int count;
 	const char *p;
 
 	if ((*string_ptr) == NULL)
 		return NULL;
 
-	for (; (**string_ptr) != '\0'; ++count, ++(*string_ptr)) {
-		for (p = delimiter; (*p) != '\0' && (**string_ptr) != (*delimiter); ++p)
+	for (; (**string_ptr) != '\0'; ++(*string_ptr)) {
+		for (p = delimiter; (*p) != '\0' && (**string_ptr) != (*p); ++p)
 			;
 
 		if ((*p) != '\0')


### PR DESCRIPTION
strtok delimiters can change between calls for the same str so you can't call strspn in advance