### PR TITLE
strncpy fix

### DIFF
--- a/arch/arm-imx/string.c
+++ b/arch/arm-imx/string.c
@@ -311,14 +311,21 @@ char *strncpy(char *dest, const char *src, size_t n)
 		ldrb r1, [r4], #1; \
 	1: \
 		cmp r2, #0; \
-		beq 2f; \
+		beq 3f; \
 		sub r2, #1; \
 		strb r1, [r3], #1; \
 		cmp r1, #0; \
 		itt ne; \
 		ldrbne r1, [r4], #1; \
 		bne 1b; \
-	2:"
+		mov r1, #0; \
+	2: \
+		cmp r2, #0; \
+		beq 3f; \
+		sub r2, #1; \
+		strb r1, [r3], #1; \
+		b 2b; \
+	3:"
 	:
 	: "r" (dest), "r" (src), "r" (n)
 	: "r1", "r2", "r3", "r4", "memory", "cc");

--- a/arch/armv7/string.c
+++ b/arch/armv7/string.c
@@ -311,14 +311,21 @@ char *strncpy(char *dest, const char *src, size_t n)
 		ldrb r1, [r4], #1; \
 	1: \
 		cmp r2, #0; \
-		beq 2f; \
+		beq 3f; \
 		sub r2, #1; \
 		strb r1, [r3], #1; \
 		cmp r1, #0; \
 		itt ne; \
 		ldrbne r1, [r4], #1; \
 		bne 1b; \
-	2:"
+		mov r1, #0; \
+	2: \
+		cmp r2, #0; \
+		beq 3f; \
+		sub r2, #1; \
+		strb r1, [r3], #1; \
+		b 2b; \
+	3:"
 	:
 	: "r" (dest), "r" (src), "r" (n)
 	: "r1", "r2", "r3", "r4", "memory", "cc");

--- a/string/string.c
+++ b/string/string.c
@@ -210,12 +210,17 @@ char *strcpy(char *dest, const char *src)
 #define __STRNCPY
 char *strncpy(char *dest, const char *src, size_t n)
 {
-	int i = 0;
+	size_t i;
 
-	do {
-		dest[i] = src[i];
-		i++;
-	} while (i < n && src[i - 1] != '\0');
+	for (i = 0; i < n; ++i) {
+		if (src[i] != '\0') {
+			dest[i] = src[i];
+		} 
+		else {
+			memset(&dest[i], '\0', n - i);
+			break;
+		}
+	}
 
 	return dest;
 }


### PR DESCRIPTION
strncpy should pad dest string with zeroes when src len is less that n