### PR TITLE
pthread: add initial impl of posix threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
 .DS_store
+.vscode/*

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PREFIX_BUILD := $(abspath $(PREFIX_BUILD))
 BUILD_DIR ?= $(PREFIX_BUILD)/$(notdir $(TOPDIR))
 BUILD_DIR := $(abspath $(BUILD_DIR))
 
-SUBSYSTEMS := math stdio stdlib string sys ctype time unistd errno signal termios posix err locale regex net syslog netinet
+SUBSYSTEMS := math stdio stdlib string sys ctype time unistd errno signal termios posix err locale regex net syslog netinet pthread
 
 LIBNAME := libphoenix.a
 LIB := $(BUILD_DIR)/$(LIBNAME)
@@ -73,7 +73,7 @@ $(ARCHS): %.a: .FORCE $(filter clean,$(MAKECMDGOALS))
 
 $(LIB): $(ARCHS) $(OBJS)
 	@echo "\033[1;34mLD $@\033[0m"
-	
+
 	@(\
 	printf "Subsystem                  | text    | rodata  | data\n";\
 	printf "=========================================================\n";\

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -5,8 +5,8 @@
  *
  * pthread
  *
- * Copyright 2017-2018 Phoenix Systems
- * Author: Pawel Pisarczyk, Michał Mirosław
+ * Copyright 2017-2018, 2019 Phoenix Systems
+ * Author: Pawel Pisarczyk, Michał Mirosław, Marcin Baran
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -17,18 +17,140 @@
 #define _LIBPHOENIX_PTHREAD_H_
 
 #include <sys/types.h>
+#include <sys/threads.h>
+#include <sched.h>
 
+
+#define EDEADLK 38
+
+#define PTHREAD_CREATE_JOINABLE 0
+#define PTHREAD_CREATE_DETACHED 1
+
+#define PTHREAD_EXPLICIT_SCHED 0
+#define PTHREAD_INHERIT_SCHED 1
+
+#define PTHREAD_PRIO_NONE 0
+#define PTHREAD_PRIO_INHERIT 1
+#define PTHREAD_PRIO_PROTECT 2
+
+#define PTHREAD_PROCESS_SHARED 0
+#define PTHREAD_PROCESS_PRIVATE 1
+
+#define PTHREAD_SCOPE_PROCESS 0
+#define PTHREAD_SCOPE_SYSTEM 1
 
 #define PTHREAD_MUTEX_INITIALIZER 0
 
+#define PTHREAD_MUTEX_DEFAULT 0
+#define PTHREAD_MUTEX_ERRORCHECK 1
+#define PTHREAD_MUTEX_NORMAL 2
+#define PTHREAD_MUTEX_RECURSIVE 3
 
-extern int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
+
+extern int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+	void *(*start_routine)(void *), void *arg);
+
+
+extern int pthread_join(pthread_t thread, void **value_ptr);
+
+
+extern int pthread_detach(pthread_t thread);
+
+
+extern pthread_t pthread_self(void);
+
+
+extern int pthread_equal(pthread_t t1, pthread_t t2);
 
 
 extern int pthread_attr_init(pthread_attr_t *attr);
 
 
 extern int pthread_attr_destroy(pthread_attr_t *attr);
+
+
+extern int pthread_attr_setstackaddr(pthread_attr_t *attr, void *stackaddr);
+
+
+extern int pthread_attr_getstackaddr(const pthread_attr_t *attr,
+	void **stackaddr);
+
+
+extern int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
+
+
+extern int pthread_attr_getstacksize(const pthread_attr_t *attr,
+	size_t *stacksize);
+
+
+extern int pthread_attr_setschedparam(pthread_attr_t *attr,
+	const struct sched_param *param);
+
+
+extern int pthread_attr_getschedparam(const pthread_attr_t *attr,
+	struct sched_param *param);
+
+
+extern int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
+
+
+extern int pthread_attr_getschedpolicy(const pthread_attr_t *attr,
+	int *policy);
+
+
+extern int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope); //TODO
+
+
+extern int pthread_attr_getscope(const pthread_attr_t *attr,
+	int *contentionscope); //TODO
+
+
+extern int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
+
+
+extern int pthread_attr_getdetachstate(const pthread_attr_t *attr,
+	int *detachstate);
+
+
+extern int pthread_attr_getinheritsched(const pthread_attr_t *restrict attr,
+	int *restrict inheritsched); //TODO
+
+
+extern int pthread_attr_setinheritsched(pthread_attr_t *attr,
+	int inheritsched); //TODO
+
+
+extern int pthread_setschedprio(pthread_t thread, int prio);
+
+
+extern int pthread_getschedparam(pthread_t thread, int *policy,
+	struct sched_param *restrict param);
+
+
+extern int pthread_setschedparam(pthread_t thread, int policy,
+	const struct sched_param *param);
+
+
+extern int pthread_mutex_destroy(pthread_mutex_t *);
+
+
+extern int pthread_mutex_init(pthread_mutex_t *restrict,
+	const pthread_mutexattr_t *restrict);
+
+
+extern int pthread_mutex_lock(pthread_mutex_t *);
+
+
+extern int pthread_mutex_trylock(pthread_mutex_t *);
+
+
+extern int pthread_mutex_unlock(pthread_mutex_t *);
+
+
+extern int pthread_mutexattr_destroy(pthread_mutexattr_t *);
+
+
+extern int pthread_mutexattr_init(pthread_mutexattr_t *);
 
 
 #endif

--- a/include/sched.h
+++ b/include/sched.h
@@ -1,0 +1,37 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * sched
+ *
+ * Copyright 2019 Phoenix Systems
+ * Author: Marcin Baran
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIBPHOENIX_SCHED_H_
+#define _LIBPHOENIX_SCHED_H_
+
+#include <errno.h>
+
+#define SCHED_FIFO 0
+#define SCHED_RR 1
+#define SCHED_OTHER 2
+
+
+struct sched_param {
+	int sched_priority;
+};
+
+
+extern int sched_get_priority_max(int policy);
+
+
+extern int sched_get_priority_min(int policy);
+
+
+#endif

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -5,8 +5,8 @@
  *
  * types.h
  *
- * Copyright 2018 Phoenix Systems
- * Author: Jan Sikorski
+ * Copyright 2018, 2019 Phoenix Systems
+ * Author: Jan Sikorski, Marcin Baran
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -49,9 +49,18 @@ typedef unsigned short u_short;
 typedef unsigned int u_int;
 typedef unsigned long u_long;
 
-typedef void *pthread_t;
-typedef void *pthread_attr_t;
+typedef struct pthread_attr_t {
+	void *stackaddr;
+	int policy;
+	int priority;
+	int detached;
+	size_t stacksize;
+} pthread_attr_t;
+
+typedef uintptr_t pthread_t;
+
 typedef handle_t pthread_mutex_t;
+typedef void *pthread_mutexattr_t;
 
 
 /* BSD legacy types permitted by POSIX */

--- a/pthread/pthread.c
+++ b/pthread/pthread.c
@@ -3,32 +3,205 @@
  *
  * libphoenix
  *
- * Doubly-linked list
+ * pthread
  *
- * Copyright 2017 Phoenix Systems
- * Author: Pawel Pisarczyk
+ * Copyright 2017, 2019 Phoenix Systems
+ * Author: Pawel Pisarczyk, Marcin Baran
  *
  * This file is part of Phoenix-RTOS.
  *
  * %LICENSE%
  */
 
-#include "pthread.h"
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/list.h>
+#include <sys/mman.h>
+#include <sys/minmax.h>
+#include <pthread.h>
 
 
-int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg)
+#define CEIL(value, size)	((((value) + (size) - 1) / (size)) * (size))
+
+
+typedef struct pthread_ctx {
+	handle_t id;
+	void *(*start_routine)(void *);
+	void *arg;
+	void *retval;
+	struct pthread_ctx *next;
+	struct pthread_ctx *prev;
+	int detached;
+} pthread_ctx;
+
+
+static pthread_ctx *pthread_list = NULL;
+
+
+static const pthread_attr_t pthread_attr_default = {
+	.stackaddr = NULL,
+	.policy = SCHED_RR,
+	.priority = 0,
+	.detached = PTHREAD_CREATE_JOINABLE,
+	.stacksize = CEIL(PTHREAD_STACK_MIN, PAGE_SIZE)
+};
+
+
+static void start_point(void *args)
 {
-	void *stack;
+	pthread_ctx *ctx = (pthread_ctx *)args;
 
-	if ((stack = malloc(PTHREAD_MIN_STACK)) == NULL)
-		return -ENOMEM;
+	ctx->retval = (void *)(ctx->start_routine(ctx->arg));
 
-	beginthread(start_routine, priority, stack, arg);
+	endthread();
+}
+
+
+static pthread_ctx *find_pthread(handle_t id)
+{
+	pthread_ctx *ctx = pthread_list;
+
+	if (ctx != NULL) {
+		do {
+			if (ctx->id == id)
+				return ctx;
+
+			ctx = ctx->next;
+		} while (ctx != pthread_list);
+	}
+
+	return NULL;
+}
+
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+	void *(*start_routine)(void *), void *arg)
+{
+	const pthread_attr_t *attrs = &pthread_attr_default;
+
+	if (attr != NULL)
+		attrs = attr;
+
+	void *stack = mmap(attrs->stackaddr, attrs->stacksize,
+		PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, NULL, 0);
+
+	if (stack == MAP_FAILED || stack == NULL)
+		return -EAGAIN;
+
+	pthread_ctx *ctx = (pthread_ctx *)malloc(sizeof(pthread_ctx));
+
+	if (ctx == NULL) {
+		munmap(stack, attrs->stacksize);
+		return -EAGAIN;
+	}
+
+	ctx->retval = NULL;
+	ctx->detached = attrs->detached;
+	ctx->start_routine = start_routine;
+	ctx->arg = arg;
+	*thread = (pthread_t)ctx;
+
+	int err = beginthreadex(start_point, attrs->priority, stack,
+		attrs->stacksize, (void *)ctx, &ctx->id);
+
+	if (err != EOK) {
+		munmap(stack, attrs->stacksize);
+		free(ctx);
+		thread = NULL;
+	}
+	else if (ctx->detached == PTHREAD_CREATE_JOINABLE) {
+		if (pthread_list != NULL && pthread_list->id == 0)
+			pthread_list = NULL;
+
+		LIST_ADD(&pthread_list, ctx);
+	}
+
+	return err;
+}
+
+
+int pthread_join(pthread_t thread, void **value_ptr)
+{
+	if (thread == pthread_self())
+		return -EDEADLK;
+
+	pthread_ctx *ctx = (pthread_ctx *)thread;
+
+	if (ctx == NULL)
+		return -EINVAL;
+
+	if (ctx->detached != PTHREAD_CREATE_DETACHED) {
+		int err;
+
+		do {
+			err = threadJoin(0);
+
+			if (err < 0) {
+				return err;
+			}
+			else if (ctx->id != err) {
+				pthread_ctx *ghost = find_pthread(err);
+				if (ghost != NULL)
+					ghost->detached = PTHREAD_CREATE_DETACHED;
+			}
+		} while (ctx->id != err);
+	}
+
+	if (value_ptr != NULL)
+		*value_ptr = ctx->retval;
+
+	LIST_REMOVE(&pthread_list, ctx);
+	free(ctx);
+
+	return EOK;
+}
+
+
+int pthread_detach(pthread_t thread)
+{
+	pthread_ctx *ctx = (pthread_ctx *)thread;
+
+	if (ctx == NULL)
+		return -ESRCH;
+
+	if (ctx->detached != PTHREAD_CREATE_JOINABLE)
+		return -EINVAL;
+
+	LIST_REMOVE(&pthread_list, ctx);
+	free(ctx);
+
+	return EOK;
+}
+
+
+pthread_t pthread_self(void)
+{
+	return (pthread_t)find_pthread(gettid());
+}
+
+
+int pthread_equal(pthread_t t1, pthread_t t2)
+{
+	return t1 == t2;
+}
+
+
+void pthread_exit(void *value_ptr)
+{
+	pthread_ctx *ctx = (pthread_ctx *)pthread_self();
+
+	if (ctx != NULL)
+		ctx->retval = value_ptr;
+
+	endthread();
 }
 
 
 int pthread_attr_init(pthread_attr_t *attr)
 {
+	*attr = pthread_attr_default;
+
 	return EOK;
 }
 
@@ -36,4 +209,235 @@ int pthread_attr_init(pthread_attr_t *attr)
 int pthread_attr_destroy(pthread_attr_t *attr)
 {
 	return EOK;
+}
+
+
+int pthread_attr_setstackaddr(pthread_attr_t *attr, void *stackaddr)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	attr->stackaddr = stackaddr;
+
+	return EOK;
+}
+
+
+int pthread_attr_getstackaddr(const pthread_attr_t *attr,void **stackaddr)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	*stackaddr = attr->stackaddr;
+
+	return EOK;
+}
+
+
+int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize)
+{
+	if (attr == NULL || stacksize < PTHREAD_STACK_MIN)
+		return -EINVAL;
+
+	attr->stacksize = CEIL(stacksize, PAGE_SIZE);
+
+	return EOK;
+}
+
+
+int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	*stacksize = attr->stacksize;
+
+	return EOK;
+}
+
+
+int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
+	size_t stacksize)
+{
+	return pthread_attr_setstackaddr(attr, stackaddr) |
+		pthread_attr_setstacksize(attr, stacksize);
+}
+
+
+int pthread_attr_getstack(const pthread_attr_t *attr, void **stackaddr,
+	size_t *stacksize)
+{
+	return pthread_attr_getstackaddr(attr, stackaddr) |
+		pthread_attr_getstacksize(attr, stacksize);
+}
+
+
+int pthread_attr_setschedparam(pthread_attr_t *attr,
+	const struct sched_param *param)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	if (param->sched_priority > sched_get_priority_max(SCHED_RR) ||
+			param->sched_priority < sched_get_priority_min(SCHED_RR))
+		return -ENOTSUP;
+
+	attr->priority = param->sched_priority;
+
+	return EOK;
+}
+
+
+int pthread_attr_getschedparam(const pthread_attr_t *attr,
+	struct sched_param *param)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	param->sched_priority = attr->priority;
+
+	return EOK;
+}
+
+
+int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy)
+{
+	if (policy < SCHED_FIFO || policy > SCHED_OTHER)
+		return -EINVAL;
+	else if (policy == SCHED_FIFO || policy == SCHED_OTHER)
+		return -ENOTSUP;
+
+	attr->policy = policy;
+
+	return EOK;
+}
+
+
+int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	*policy = attr->policy;
+
+	return EOK;
+}
+
+
+int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope)
+{
+	return EOK;
+}
+
+int pthread_attr_getscope(const pthread_attr_t *attr,
+	int *contentionscope)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	return EOK;
+}
+
+
+int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate)
+{
+	if (detachstate != PTHREAD_CREATE_DETACHED ||
+			detachstate != PTHREAD_CREATE_JOINABLE)
+		return -EINVAL;
+
+	attr->detached = detachstate;
+
+	return EOK;
+}
+
+
+int pthread_attr_getdetachstate(const pthread_attr_t *attr,
+	int *detachstate)
+{
+	if (attr == NULL)
+		return -EINVAL;
+
+	*detachstate = attr->detached;
+
+	return EOK;
+}
+
+
+int pthread_attr_getinheritsched(const pthread_attr_t *restrict attr,
+	int *restrict inheritsched);
+
+
+int pthread_attr_setinheritsched(pthread_attr_t *attr,
+	int inheritsched);
+
+
+int pthread_setschedprio(pthread_t thread, int prio);
+
+
+int pthread_getschedparam(pthread_t thread, int *policy,
+	struct sched_param *restrict param);
+
+
+int pthread_setschedparam(pthread_t thread, int policy,
+	const struct sched_param *param);
+
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+	(void)attr;
+
+	return mutexCreate(mutex);
+}
+
+
+int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+	if (mutex == NULL)
+		return -EINVAL;
+
+	return mutexLock(*mutex);
+}
+
+
+int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+	if (mutex == NULL)
+		return -EINVAL;
+
+	return mutexTry(*mutex);
+}
+
+
+int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+	if (mutex == NULL)
+		return -EINVAL;
+
+	return mutexUnlock(*mutex);
+}
+
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+	if (mutex == NULL)
+		return -EINVAL;
+
+	return resourceDestroy(*mutex);
+}
+
+
+int sched_get_priority_max(int policy)
+{
+	if (policy == SCHED_RR)
+		return 7;
+
+	return -EINVAL;
+}
+
+int sched_get_priority_min(int policy)
+{
+	if (policy == SCHED_RR)
+		return 0;
+
+	return -EINVAL;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,7 @@
 PREFIX_PROG := $(PREFIX_BUILD)/prog/
 PREFIX_PROG_STRIPPED := $(PREFIX_BUILD)/prog.stripped/
 
-PROGS := test_mmap test_malloc test_threads test_str2num test_scanf test_msg test_env test_signals test_condwait
+PROGS := test_mmap test_malloc test_threads test_str2num test_scanf test_msg test_env test_signals test_condwait test_pthreads
 
 # include after all dependencies are set
 include $(TOPDIR)/Makefile.rules

--- a/test/test_pthreads.c
+++ b/test/test_pthreads.c
@@ -1,0 +1,309 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * test/test_pthreads
+ *
+ * Copyright 2019 Phoenix Systems
+ * Author: Marcin Baran
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include "pthread.h"
+
+#define TEST_CREATE_JOIN_NUM 100
+#define TEST_MUTEX 5
+#define TEST_EQUAL 2
+
+
+static void *worker(void *arg)
+{
+	if (arg != NULL)
+		printf("Worker thread %d created\n", *(int *)arg);
+
+	return arg;
+}
+
+static void *worker_busy(void *arg)
+{
+	printf("Busy worker thread %d created\n", (int)arg);
+
+	usleep(100);
+
+	return arg;
+}
+
+
+/*
+ * Pthread test create/join simple thread:
+ */
+
+static int test_pthread_create_join(int num_threads)
+{
+	pthread_t thread;
+	void *result = NULL;
+	int passed = 0;
+	int failed = 0;
+	int err = 0;
+	int arg = 0;
+	int i;
+
+	for (i = 0; i < num_threads; i++) {
+		arg = i;
+		printf("Creating thread %d\n", i);
+		if ((err = pthread_create(&thread, NULL, worker, (void *)&arg)) != EOK) {
+			printf("Failed to create thread %d. Error: %d\n", i, err);
+			++failed;
+			continue;
+		}
+
+		printf("Joining thread %d\n", i);
+		if ((err = pthread_join(thread, &result)) != EOK) {
+			printf("Failed to join thread %d. Error: %d\n", i, err);
+			++failed;
+		}
+		else if (result != (void *)&arg) {
+			printf("Wrong return value from thread %d\n", i);
+			++failed;
+		}
+		else {
+			++passed;
+		}
+	}
+
+	printf("\n%s tests passed: %d, failed: %d\n\n", __func__, passed, failed);
+
+	return passed;
+};
+
+/*
+ * Pthread test threads equal
+ */
+
+static int test_pthread_equal(void)
+{
+	pthread_t t1, t2;
+	int passed = 0;
+
+	if (pthread_create(&t1, NULL, worker, NULL) == EOK &&
+			pthread_create(&t2, NULL, worker, NULL) == EOK) {
+
+		printf("Created 2 threads\n");
+
+		passed += pthread_equal(t1, t1);
+		passed += !pthread_equal(t1, t2);
+
+		pthread_join(t1, NULL);
+		pthread_join(t2, NULL);
+
+	}
+	else {
+		printf("Failed to create 2 threads\n");
+	}
+
+	printf("\n%s tests passed: %d, failed: %d\n\n", __func__,
+		passed, 2 - passed);
+
+	return passed;
+};
+
+/*
+ * Pthread test lock/trylock/unlock mutex:
+ */
+
+static int test_pthread_lock_unlock_mutex(void)
+{
+	pthread_mutex_t mutex;
+	int passed = 0;
+	int err = 0;
+
+	printf("Creating mutex\n");
+
+	if ((err = pthread_mutex_init(&mutex, NULL)) != EOK) {
+		printf("Could not create mutex. Error: %d\n", err);
+		goto DESTROY;
+	}
+
+	++passed;
+
+	printf("Locking mutex\n");
+
+	if ((err = pthread_mutex_lock(&mutex)) != EOK) {
+		printf("Could not lock mutex. Error: %d\n", err);
+		goto DESTROY;
+	}
+
+	++passed;
+
+	printf("Trylock on mutex (should fail now)\n");
+
+	if ((err = pthread_mutex_trylock(&mutex)) == EOK)
+		printf("Trylock succeeded even though mutex locked\n");
+	else
+		++passed;
+
+	printf("Unlocking mutex\n");
+
+	if ((err = pthread_mutex_unlock(&mutex)) != EOK)
+		printf("Could not unlock mutex. Error: %d\n", err);
+	else
+		++passed;
+
+DESTROY:
+
+	printf("Destroying mutex\n");
+
+	if ((err = pthread_mutex_destroy(&mutex)) != EOK)
+		printf("Could not destroy mutex. Error: %d\n", err);
+	else
+		++passed;
+
+	printf("\n%s tests passed: %d, failed: %d\n\n", __func__,
+			passed, 5 - passed);
+
+	return passed;
+};
+
+/*
+ * Pthread test create/join multiple threads:
+ */
+
+static int test_pthread_create_join_multiple(int num_threads)
+{
+	pthread_attr_t attr;
+	struct sched_param param = {.sched_priority = 0};
+	pthread_t *threads = malloc(num_threads * sizeof(pthread_t));
+
+	int passed = 0;
+	int failed = 0;
+	void *result = NULL;
+	int err = 0;
+	int arg = 0;
+	int i;
+
+	pthread_attr_init(&attr);
+
+	for (i = 0; i < num_threads; i++) {
+		param.sched_priority = i % sched_get_priority_max(SCHED_RR);
+		printf("Creating thread %d with priority %d\n",
+			i, param.sched_priority);
+
+		pthread_attr_setschedparam(&attr, &param);
+		arg = i;
+
+		if ((err = pthread_create(&threads[i], &attr, worker_busy,(void *)arg))
+				!= EOK) {
+			printf("Failed to create thread %d. Error: %d\n", i, err);
+			++failed;
+		}
+	}
+
+	for (i = 0; i < num_threads; ++i) {
+		printf("Joining thread %d\n", i);
+		arg = i;
+
+		if ((err = pthread_join(threads[i], &result)) != EOK) {
+			printf("Failed to join thread %d. Error: %d\n", i, err);
+			++failed;
+		}
+		else if ((int)result != arg) {
+			printf("Wrong return value from thread %d\n", i);
+			++failed;
+		}
+		else {
+			++passed;
+		}
+	}
+
+	free(threads);
+
+	printf("\n%s tests passed: %d, failed: %d\n\n", __func__, passed, failed);
+
+	return passed;
+}
+
+
+/*
+ * Pthread test create/detach threads:
+ */
+
+static int test_pthread_create_detach(int num_threads)
+{
+	pthread_t thread;
+	int passed = 0;
+	int failed = 0;
+	int err = 0;
+	int i;
+
+	for (i = 0; i < num_threads; i++) {
+		printf("Creating thread %d\n", i);
+		if ((err = pthread_create(&thread, NULL, worker_busy, NULL)) != EOK) {
+			printf("Failed to create thread %d. Error: %d\n", i, err);
+			++failed;
+			continue;
+		}
+
+		printf("Detaching thread %d\n", i);
+		if ((err = pthread_detach(thread)) != EOK) {
+			printf("Failed to detach thread %d. Error: %d\n", i, err);
+			++failed;
+			continue;
+		}
+
+		printf("Detaching already detached thread\n");
+		if ((err = pthread_detach(thread)) != EOK) {
+			printf("Detaching thread %d failed as it should. Error: %d\n", i, err);
+			++passed;
+		}
+		else {
+			printf("Detaching thread should fail %d. Error: %d\n", i, err);
+			++failed;
+		}
+	}
+
+	printf("\n%s tests passed: %d, failed: %d\n\n", __func__, passed, failed);
+
+	return passed;
+};
+
+
+int main(void)
+{
+	int passed = 0;
+	int num_tests = 0;
+
+	printf("test_pthreads: Starting, main is at %p\n\n", main);
+
+	printf("test_pthreads: Testing thread create/join:\n");
+	passed += test_pthread_create_join(TEST_CREATE_JOIN_NUM);
+	num_tests += TEST_CREATE_JOIN_NUM;
+
+	printf("test_pthreads: Testing multiple thread create/join:\n");
+	passed += test_pthread_create_join_multiple(TEST_CREATE_JOIN_NUM);
+	num_tests += TEST_CREATE_JOIN_NUM;
+
+	printf("test_pthreads: Testing threads equal:\n");
+	passed += test_pthread_equal();
+	num_tests += TEST_EQUAL;
+
+	printf("test_pthreads: Testing lock/unlock mutex:\n");
+	passed += test_pthread_lock_unlock_mutex();
+	num_tests += TEST_MUTEX;
+
+	printf("test_pthreads: Testing thread create/detach:\n");
+	passed += test_pthread_create_detach(TEST_CREATE_JOIN_NUM);
+	num_tests += TEST_CREATE_JOIN_NUM;
+
+	printf("\ntest_pthreads: %d PASSED\n", passed);
+	printf("test_pthreads: %d FAILED\n", num_tests - passed);
+
+	return 0;
+}


### PR DESCRIPTION
Initial implementation contains basic pthread operations (create, join, detach) as well as pthread attributes setting and basic mutexes. Not all operation modes are supported yet. The test_pthreads.c contains tests for implemented functionalities.