### PR TITLE
dirent.h: Add dtSymlink dirent type

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -26,6 +26,7 @@
 enum {	dtDir = 0,
 		dtFile,
 		dtDev,
+		dtSymlink,
 		dtUnknown
 };
 


### PR DESCRIPTION
This change is necessary for my new implementation of ls utility.