### PR TITLE
malloc_dl: malloc_chunkCanSplit() quick fix for RISC-V

### DIFF
--- a/stdlib/malloc_dl.c
+++ b/stdlib/malloc_dl.c
@@ -247,7 +247,7 @@ static void _malloc_chunkRemove(chunk_t *chunk)
 
 static inline int malloc_chunkCanSplit(chunk_t *chunk, size_t size)
 {
-	return (malloc_chunkSize(chunk) >= size + CHUNK_MIN_SIZE);
+	return (size >= CHUNK_OVERHEAD) && (malloc_chunkSize(chunk) >= size + CHUNK_MIN_SIZE);
 }
 
 


### PR DESCRIPTION
_malloc_chunkSplit() caused load page fault exception on RISC-V by assuming that 'size' parameter is greater than CHUNK_OVERHEAD (for RISC-V64 it's 16 bytes instead of 8 bytes on a 32-bit architecture).