### PR TITLE
sys/mman.h: added predefined oid for contiguous physical memory alloc…

### DIFF
--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -24,6 +24,7 @@
 /* Predefined oids */
 #define OID_NULL         NULL
 #define OID_PHYSMEM      (void *)-1
+#define OID_CONTIGUOUS   (void *)-2
 
 
 #define MAP_ANON	MAP_ANONYMOUS


### PR DESCRIPTION
…ation
PR with added physical memory allocation in phoenix-rtos-kernel: [link](https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/169)