### PR TITLE
sys/mman.h: moved predefined oids definitions to phoenix/mman.h

### DIFF
--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -21,16 +21,8 @@
 #include <phoenix/mman.h>
 
 
-/* Predefined oids */
-#define OID_NULL         NULL
-#define OID_PHYSMEM      (void *)-1
-#define OID_CONTIGUOUS   (void *)-2
-
-
-#define MAP_ANON	MAP_ANONYMOUS
-
-
-#define MAP_FAILED     (void *)-1
+#define MAP_ANON   MAP_ANONYMOUS
+#define MAP_FAILED (void *)-1
 
 
 extern void mmdump(void);


### PR DESCRIPTION
PR with changes on kernel side: [link](https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/170)