### PR TITLE
Host build

### DIFF
--- a/Makefile.host
+++ b/Makefile.host
@@ -1,0 +1,42 @@
+#
+# Makefile for minimal libphoenix prepared for host
+#
+# Copyright 2018-2021 Phoenix Systems
+#
+# %LICENSE%
+#
+
+SIL ?= @
+MAKEFLAGS += --no-print-directory
+
+TARGET ?= host-pc
+
+include ../phoenix-rtos-build/Makefile.common
+include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
+
+# establish sysroot
+LIBNAME := libphoenix.a
+
+CFLAGS += -Iinclude -fno-builtin-malloc
+
+HEADERS := sys/rb.h
+HEADERS := $(patsubst %,$(PREFIX_H)%,$(HEADERS))
+OBJS := sys/rb.o
+OBJS := $(patsubst %,$(PREFIX_O)%,$(OBJS))
+
+
+all: $(PREFIX_A)$(LIBNAME) $(HEADERS)
+
+$(PREFIX_A)$(LIBNAME): $(OBJS)
+	$(ARCH)
+
+$(PREFIX_H)%.h: include/%.h
+	$(HEADER)
+
+.PHONY: clean
+clean:
+	@echo "rm -rf $(BUILD_DIR)"
+
+ifneq ($(filter clean,$(MAKECMDGOALS)),)
+	$(shell rm -rf $(BUILD_DIR))
+endif

--- a/include/strings.h
+++ b/include/strings.h
@@ -25,7 +25,7 @@ extern int strcasecmp(const char *str1, const char *str2);
 
 
 /* Compares at most the first n bytes of str1 and str2 case-insensitively. */
-extern int strncasecmp(const char *s1, const char *s2, int n);
+extern int strncasecmp(const char *s1, const char *s2, size_t n);
 
 
 #endif

--- a/string/string.c
+++ b/string/string.c
@@ -72,7 +72,7 @@ int strcasecmp(const char *s1, const char *s2)
 
 #ifndef __STRNCASECMP
 #define __STRNCASECMP
-int strncasecmp(const char *s1, const char *s2, int n)
+int strncasecmp(const char *s1, const char *s2, size_t n)
 {
 	const char *p;
 	unsigned int k;

--- a/sys/rb.c
+++ b/sys/rb.c
@@ -14,7 +14,6 @@
  */
 
 #include <sys/rb.h>
-#include <errno.h>
 #include <string.h>
 
 


### PR DESCRIPTION
Added special Makefile for build mininmal libphoenix on host, currently only with rbtree. As main Makefile is prepared for instalation into the toolchain, I think it's cleaner to just have another Makefile.

You can test the build just by typing make -f Makefile.host

Along with this changes, I include two other simple fixes that I found when building libphoenix with host toolchain. 