### PR TITLE
ioctl: Add missing definition required by lwip

### DIFF
--- a/include/sys/ioctl.h
+++ b/include/sys/ioctl.h
@@ -47,6 +47,7 @@
 
 
 #define	FIONREAD		_IOR('f', 127, int)
+#define	FIONBIO			_IOW('f', 126, unsigned long)
 
 
 int ioctl(int fd, unsigned long cmd, ... );


### PR DESCRIPTION
This is required in order to silence warnings when compiling `phoenix-rtos-lwip/port/sockets.c`. They are caused by `lwip` defining the same macros as `libphoenix`. However, the following `lwip` header line could prevent it:
https://github.com/phoenix-rtos/lwip/blob/721dadbba18e7b3da383766373bf8275c690e688/src/include/lwip/sockets.h#L402
if we include necessary definitions before including `lwip/socket.h`. This PR should help with that and provide an ioctl `FIONBIO` definition to user-space programs, which use `libphoenix` headers and not `lwip`.

lwip PR eventually fixing the warnings: https://github.com/phoenix-rtos/phoenix-rtos-lwip/pull/17