### PR TITLE
calloc(): corrected checking of the maximum alocated size

### DIFF
--- a/stdlib/malloc_dl.c
+++ b/stdlib/malloc_dl.c
@@ -437,9 +437,9 @@ void *malloc(size_t size)
 void *calloc(size_t nitems, size_t size)
 {
 	void *ptr;
-	uint64_t allocSize = nitems * size;
+	uint64_t allocSize = (uint64_t)nitems * size;
 
-	if (allocSize > UINT_MAX)
+	if (allocSize > (uint64_t)UINT_MAX)
 		return NULL;
 
 	if ((ptr = malloc((size_t) allocSize)) == NULL)


### PR DESCRIPTION
Currently the least significant 32 bits of the result `nitems * size` are passed to `malloc()` without checking of the most significant bits.

Disassembly for `armv7a7`
Currently:
```
00000000 <calloc>:
   0:	b538      	push	{r3, r4, r5, lr}
   2:	fb01 f500 	mul.w	r5, r1, r0
   6:	4628      	mov	r0, r5
   8:	f7ff fffe 	bl	0 <calloc>	8: R_ARM_THM_CALL	malloc
```
After correction:
```
00000000 <calloc>:
   0:	b5d0      	push	{r4, r6, r7, lr}
   2:	fba0 6701 	umull	r6, r7, r0, r1
   6:	2f01      	cmp	r7, #1
   8:	bf08      	it	eq
   a:	2e00      	cmpeq	r6, #0
   c:	d20a      	bcs.n	24 <calloc+0x24>
   e:	4630      	mov	r0, r6
  10:	f7ff fffe 	bl	0 <calloc>	10: R_ARM_THM_CALL	malloc
```
