### PR TITLE
imxrt: fix platformctl reboot

### DIFF
--- a/arch/armv7m/reboot.c
+++ b/arch/armv7m/reboot.c
@@ -15,10 +15,18 @@
 
 #include <sys/reboot.h>
 #include <sys/platform.h>
-#include <errno.h>
+#include <phoenix/arch/imxrt.h>
 
 
 int reboot(int magic)
 {
-	return -EINVAL;
+	platformctl_t pctl = {
+		.action = pctl_set,
+		.type = pctl_reboot,
+		.reboot = {
+			.magic = magic
+		}
+	};
+
+	return platformctl(&pctl);
 }


### PR DESCRIPTION
This fix enables `psh` to act as expected (do reboot) on imxrt. Additionaly `platformctl` fix in the kernel is required which is available in separate PR (https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/192)

JIRA: RTOS-14