### PR TITLE
unistd/getopt: fixed -Wmaybe-uninitialized warning

### DIFF
--- a/unistd/getopt.c
+++ b/unistd/getopt.c
@@ -103,7 +103,7 @@ static void rotate_right(char **dest, char **src)
 
 int getopt_long(int argc, char * const argv[], const char *optstring, const struct option *longopts, int *longindex)
 {
-	char *opt, *name;
+	char *name, *opt = NULL;
 	int skipped, resumed;
 	int i, colon, ret;
 


### PR DESCRIPTION
JIRA: RTOS-17

The `opt` variable which causes the warning is always initialized (it's guaranteed by `if (name != NULL)` check) however the compiler still complains. Added explicit `opt = NULL` initialization to get rid of the warning.