### PR TITLE
Real pathname resolution

### DIFF
--- a/include/arch/arm-imx/limits.h
+++ b/include/arch/arm-imx/limits.h
@@ -6,7 +6,7 @@
  * Architecture dependent part of limits (arch/arm-imx)
  *
  * Copyright 2017-2019 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski, Marek Bialowas
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -49,12 +49,18 @@
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN  256
-#define PATH_MAX           1024
-#define ARG_MAX            32000
-#define _POSIX2_RE_DUP_MAX 255
-
 #define PAGE_SIZE _PAGE_SIZE
 #define PAGESIZE  _PAGE_SIZE
+
+#define PTHREAD_STACK_MIN 256
+
+/*** POSIX-required defines ***/
+
+#define PATH_MAX    1024  /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
+#define NAME_MAX    256   /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
+#define ARG_MAX     32000 /* Maximum length of argument to the exec functions including environment data. MIN: 4096 */
+#define SYMLOOP_MAX 8     /* Maximum number of symbolic links that can be reliably traversed in the resolution of a pathname in the absence of a loop. MIN: 8 */
+
+#define _POSIX2_RE_DUP_MAX 255
 
 #endif

--- a/include/arch/armv7/limits.h
+++ b/include/arch/armv7/limits.h
@@ -6,7 +6,7 @@
  * Architecture dependent part of limits (arch/armv7)
  *
  * Copyright 2017-2019 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski, Marek Bialowas
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -49,12 +49,18 @@
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN  256
-#define PATH_MAX           1024
-#define ARG_MAX            1500
-#define _POSIX2_RE_DUP_MAX 255
-
 #define PAGE_SIZE _PAGE_SIZE
 #define PAGESIZE  _PAGE_SIZE
+
+#define PTHREAD_STACK_MIN 256
+
+/*** POSIX-required defines ***/
+
+#define PATH_MAX    256  /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
+#define NAME_MAX    64   /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
+#define ARG_MAX     1500 /* Maximum length of argument to the exec functions including environment data. MIN: 4096 */
+#define SYMLOOP_MAX 8    /* Maximum number of symbolic links that can be reliably traversed in the resolution of a pathname in the absence of a loop. MIN: 8 */
+
+#define _POSIX2_RE_DUP_MAX 255
 
 #endif

--- a/include/arch/ia32/limits.h
+++ b/include/arch/ia32/limits.h
@@ -6,7 +6,7 @@
  * Architecture dependent part of limits (arch/ia32)
  *
  * Copyright 2017-2019 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski, Marek Bialowas
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -49,12 +49,18 @@
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN  256
-#define PATH_MAX           1024
-#define ARG_MAX            32000
-#define _POSIX2_RE_DUP_MAX 255
-
 #define PAGE_SIZE _PAGE_SIZE
 #define PAGESIZE  _PAGE_SIZE
+
+#define PTHREAD_STACK_MIN 256
+
+/*** POSIX-required defines ***/
+
+#define PATH_MAX    1024  /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
+#define NAME_MAX    256   /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
+#define ARG_MAX     32000 /* Maximum length of argument to the exec functions including environment data. MIN: 4096 */
+#define SYMLOOP_MAX 8     /* Maximum number of symbolic links that can be reliably traversed in the resolution of a pathname in the absence of a loop. MIN: 8 */
+
+#define _POSIX2_RE_DUP_MAX 255
 
 #endif

--- a/include/arch/riscv64/limits.h
+++ b/include/arch/riscv64/limits.h
@@ -3,10 +3,10 @@
  *
  * libphoenix
  *
- * Architecture dependent part of limits (arch/ia32)
+ * Architecture dependent part of limits (arch/riscv64)
  *
  * Copyright 2017-2019 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Andrzej Glowinski, Marek Bialowas
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -49,12 +49,18 @@
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN  256
-#define PATH_MAX           1024
-#define ARG_MAX            32000
-#define _POSIX2_RE_DUP_MAX 255
-
 #define PAGE_SIZE _PAGE_SIZE
 #define PAGESIZE  _PAGE_SIZE
+
+#define PTHREAD_STACK_MIN 256
+
+/*** POSIX-required defines ***/
+
+#define PATH_MAX    1024  /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
+#define NAME_MAX    256   /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
+#define ARG_MAX     32000 /* Maximum length of argument to the exec functions including environment data. MIN: 4096 */
+#define SYMLOOP_MAX 8     /* Maximum number of symbolic links that can be reliably traversed in the resolution of a pathname in the absence of a loop. MIN: 8 */
+
+#define _POSIX2_RE_DUP_MAX 255
 
 #endif

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -20,8 +20,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#define NAME_MAX 128
-
 /* dirent types */
 enum {	dtDir = 0,
 		dtFile,

--- a/include/errno.h
+++ b/include/errno.h
@@ -22,6 +22,7 @@
 /* Linux/x86-compatible numbers for easier debugging */
 
 #define ENOTEMPTY       39
+#define ELOOP           40
 #define EUNATCH         49
 #define ENODATA         61
 #define ENONET          64

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -216,16 +216,16 @@ extern int unlockpt(int fd);
 
 
 /* Return canonicalized absolute path, to be deallocated with free() */
-char *canonicalize_file_name(const char *path);
+extern char *canonicalize_file_name(const char *path);
 
 
 /* Return the canonicalized absolute pathname, stored in resolved_path (up to PATH_MAX bytes) */
-char *realpath(const char *path, char *resolved_path);
+extern char *realpath(const char *path, char *resolved_path);
 
 
 /* Resolve path to absolute path with '.', '..' and symlinks support. Additional params to satisfy multiple libc use cases.
- * NOTE: stack usage: ~(2 * PATH_MAX) */
-char *resolve_path(const char *path, char *resolved_path, int resolve_last_symlink, int allow_missing_leaf);
+ * NOTE: stack usage: ~PATH_MAX */
+extern char *resolve_path(const char *path, char *resolved_path, int resolve_last_symlink, int allow_missing_leaf);
 
 
 double strtod(const char *restrict nptr, char **restrict endptr);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -219,6 +219,15 @@ extern int unlockpt(int fd);
 char *canonicalize_file_name(const char *path);
 
 
+/* Return the canonicalized absolute pathname, stored in resolved_path (up to PATH_MAX bytes) */
+char *realpath(const char *path, char *resolved_path);
+
+
+/* Resolve path to absolute path with '.', '..' and symlinks support. Additional params to satisfy multiple libc use cases.
+ * NOTE: stack usage: ~(2 * PATH_MAX) */
+char *resolve_path(const char *path, char *resolved_path, int resolve_last_symlink, int allow_missing_leaf);
+
+
 double strtod(const char *restrict nptr, char **restrict endptr);
 
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -151,10 +151,12 @@ extern int dup2(int fildes, int fildes2);
 extern void _exit(int status);
 
 
-extern int symlink(const char *path1, const char *path2);
+/* Creates a symbolic link named linkpath which contains the string target. If linkpath exists, it will not be overwritten. */
+extern int symlink(const char *target, const char *linkpath);
 
 
-extern int link(const char *path1, const char *path2);
+/* Creates a new link (also known as a hard link) to an existing file. If newpath exists, it will not be overwritten. */
+extern int link(const char *oldpath, const char *newpath);
 
 
 extern int unlink(const char *pathname);

--- a/sys/stat.c
+++ b/sys/stat.c
@@ -143,6 +143,11 @@ int mkdir(const char *path, mode_t mode)
 	if (name == canonical_name) {
 		name++;
 		parent = "/";
+
+		if (*name == 0) { /* special case - "/" */
+			free(canonical_name);
+			return SET_ERRNO(-EEXIST);
+		}
 	}
 	else {
 		*(name++) = 0;

--- a/sys/time.c
+++ b/sys/time.c
@@ -26,7 +26,11 @@ int utimes(const char *filename, const struct timeval times[2])
 {
 	char *canonical;
 	int err;
-	canonical = canonicalize_file_name(filename);
+
+	/* TODO: should we resolve last symlink here ? */
+	if ((canonical = resolve_path(filename, NULL, 1, 0)) == NULL)
+		return -1; /* errno set by resolve_path */
+
 	err = sys_utimes(canonical, times);
 	free(canonical);
 	return SET_ERRNO(err);


### PR DESCRIPTION
## Description
This change brings real path resolution to Phoenix-RTOS (with '.', '..' and symlinks support (depends on FS used)) with correct errno reporting.

**WARN: This is a breaking change as canonicalize_path_name() works now according to POSIX (which previous implementation was non-conformant with). For internal usage please use either POSIX API or native resolve_path() with extended functionality.**

## Motivation and Context
JIRA: DTR-75
phoenix-rtos/phoenix-rtos-project#113

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/29
- [x] Tested by hand on: **ia32-generic** (ext2), **DTR** (jffs, dummyfs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
  - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/204
  - https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/39
- [x] I will merge this PR by myself when appropriate.
