### PR TITLE
uio: fix readv & writev return value, set EINVAL errno

### DIFF
--- a/sys/uio.c
+++ b/sys/uio.c
@@ -42,16 +42,21 @@ ssize_t readv(int fd, const struct iovec *iov, int iovcnt)
 	unsigned int i;
 	ssize_t n, tot_len = 0;
 
-	if (-1 == checkv(iov, iovcnt))
-		return -EINVAL;
+	if (-1 == checkv(iov, iovcnt)) {
+		errno = EINVAL;
+		return -1;
+	}
 
 	/* TODO: file locking */
 
 	for (i = 0; i < iovcnt; ++i) {
 		if (iov[i].iov_len > 0) {
 			n = read(fd, iov[i].iov_base, iov[i].iov_len);
-			if (n == -1)
+			if (n < 0) {
+				if (tot_len > 0 && (errno == EINTR || errno == EAGAIN))
+					break;
 				return -1;
+			}
 
 			tot_len += n;
 
@@ -69,16 +74,21 @@ ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
 	unsigned int i;
 	ssize_t n, tot_len = 0;
 
-	if (-1 == checkv(iov, iovcnt))
-		return -EINVAL;
+	if (-1 == checkv(iov, iovcnt)) {
+		errno = EINVAL;
+		return -1;
+	}
 
 	/* TODO: file locking */
 
 	for (i = 0; i < iovcnt; ++i) {
 		if (iov[i].iov_len > 0) {
 			n = write(fd, iov[i].iov_base, iov[i].iov_len);
-			if (n == -1)
+			if (n < 0) {
+				if (tot_len > 0 && (errno == EINTR || errno == EAGAIN))
+					break;
 				return -1;
+			}
 
 			tot_len += n;
 


### PR DESCRIPTION
According to POSIX:

1. If a read() is interrupted by a signal before it reads any
data, it shall return -1 with errno set to [EINTR].
2. If a read() is interrupted by a signal after it has
successfully read some data, it shall return the number of
bytes read.
3. If write() is interrupted by a signal before it writes any
data, it shall return -1 with errno set to [EINTR].
4. If write() is interrupted by a signal after it successfully
writes some data, it shall return the number of bytes written.

JIRA: RTOS-46

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current implementation of readv/writev breaks dropbear (channel write).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
