### PR TITLE
setjmp: fix alignments

### DIFF
--- a/arch/armv7m/jmp.S
+++ b/arch/armv7m/jmp.S
@@ -23,7 +23,7 @@
 .type _setjmp, %function
 _setjmp:
 	/* set jump address and stack pointer */
-	addw r1, pc, #((1f - . - 4) | 1) /* 4 is the size of addw instruction itself */
+	ldr r1, =(1f + 1)
 	mov r2, sp
 	/* store everythig in jmpbuf */
 	stm r0, {r1-r2, r4-r11, lr}
@@ -62,17 +62,21 @@ setjmp:
 	mov r3, r0
 	pop {r0, lr}
 	/* set jump address and stack pointer */
-	addw r1, pc, #((1f - . - 4) | 1) /* 4 is the size of addw instruction itself */
+	ldr r1, =(1f + 1)
 	mov r2, sp
 	/* store everythig in jmpbuf */
-	stm r0, {r1-r2, r4-r11, lr}
+	stmia r0!, {r1-r2, r4-r11, lr}
+	/* save signal mask */
+	str r3, [r0]
 	mov r0, #0
 	bx lr
 1:
 	/* this is where we land after the jump
 	 * r0 is now pointing to signal mask
 	 * which we want to restore */
-	push {r1, r4, lr}
+
+	 /* push r2 to align stack to 8 bytes before call */
+	push {r1-r2, r4, lr}
 	ldr r4, [r0]
 	mov r0, r4
 	mov r4, r3
@@ -80,7 +84,7 @@ setjmp:
 	bl signalMask
 	/* set return value and pop the stack */
 	mov r0, r4
-	pop {r1, r4, lr}
+	pop {r1-r2, r4, lr}
 	bx lr
 .size setjmp, .-setjmp
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
1. Use ldr instead of addw
2. Add storing mask
3. Fix stack alignment before syscall
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. In the Thumb mode PC points to the address of an executing instruction + 2 next instructions (4 bytes). But, read of PC value in 
`add` instruction is always word-aligned (when instructions are half-word aligned). So, if line `addw r1, pc, #((1f - . - 4) | 1)` is half-word aligned then `r1` has value moved by 2 bytes. (A5.1.2 Reference Manual ARMv7m or [here](https://www.keil.com/support/man/docs/armasm/armasm_dom1361289861747.htm))
2. Just add missing mask store.
3. When pushing context to stack, the hardware saves eight 32-bit words, comprising xPSR, ReturnAddress, LR (R14), R12, R3, R2, R1, and R0. If stack is not aligned to 8 bytes and `CCR.STKALIGN` is set 1 (by default is 1) then additionally stack is aligned to 8 bytes. Kernel does not take into account this alignment so make sure stack is aligned before syscall. (B1.5.6-7 Reference Manual ARMv7m)

I'm not an expert of ARM architecture so I'd appreciate any feedback if I handled it right.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m7-imxrt106x using [this test](https://github.com/phoenix-rtos/phoenix-rtos-tests/blob/master/setjmp/setjmp.c)).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
