### PR TITLE
include: increase the ARG_MAX value

### DIFF
--- a/include/arch/arm-imx/limits.h
+++ b/include/arch/arm-imx/limits.h
@@ -51,7 +51,7 @@
 
 #define PTHREAD_STACK_MIN  256
 #define PATH_MAX           1024
-#define ARG_MAX            128
+#define ARG_MAX            32000
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE

--- a/include/arch/arm-imx/limits.h
+++ b/include/arch/arm-imx/limits.h
@@ -28,33 +28,33 @@
 
 #define MB_LEN_MAX 4
 
-#define SHRT_MIN -32768
-#define SHRT_MAX 32767
+#define SHRT_MIN  -32768
+#define SHRT_MAX  32767
 #define USHRT_MAX 65535
 
-#define INT_MIN -2147483648
-#define INT_MAX 0x7fffffff
+#define INT_MIN  -2147483648
+#define INT_MAX  0x7fffffff
 #define UINT_MAX 0xffffffff
 
-#define LONG_MIN INT_MIN
-#define LONG_MAX INT_MAX
+#define LONG_MIN  INT_MIN
+#define LONG_MAX  INT_MAX
 #define ULONG_MAX UINT_MAX
 
-#define LONG_LONG_MIN 0x8000000000000000LL
-#define LONG_LONG_MAX 0x7fffffffffffffffLL
+#define LONG_LONG_MIN  0x8000000000000000LL
+#define LONG_LONG_MAX  0x7fffffffffffffffLL
 #define ULONG_LONG_MAX 0xffffffffffffffffLL
-#define LLONG_MIN LONG_LONG_MIN
-#define LLONG_MAX LONG_LONG_MAX
-#define ULLONG_MAX ULONG_LONG_MAX
+#define LLONG_MIN      LONG_LONG_MIN
+#define LLONG_MAX      LONG_LONG_MAX
+#define ULLONG_MAX     ULONG_LONG_MAX
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN 256
-#define PATH_MAX 1024
-#define ARG_MAX 128
+#define PTHREAD_STACK_MIN  256
+#define PATH_MAX           1024
+#define ARG_MAX            128
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE
-#define PAGESIZE _PAGE_SIZE
+#define PAGESIZE  _PAGE_SIZE
 
 #endif

--- a/include/arch/armv7/limits.h
+++ b/include/arch/armv7/limits.h
@@ -51,7 +51,7 @@
 
 #define PTHREAD_STACK_MIN  256
 #define PATH_MAX           1024
-#define ARG_MAX            128
+#define ARG_MAX            1500
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE

--- a/include/arch/armv7/limits.h
+++ b/include/arch/armv7/limits.h
@@ -28,33 +28,33 @@
 
 #define MB_LEN_MAX 4
 
-#define SHRT_MIN -32768
-#define SHRT_MAX 32767
+#define SHRT_MIN  -32768
+#define SHRT_MAX  32767
 #define USHRT_MAX 65535
 
-#define INT_MIN -2147483648
-#define INT_MAX 0x7fffffff
+#define INT_MIN  -2147483648
+#define INT_MAX  0x7fffffff
 #define UINT_MAX 0xffffffff
 
-#define LONG_MIN INT_MIN
-#define LONG_MAX INT_MAX
+#define LONG_MIN  INT_MIN
+#define LONG_MAX  INT_MAX
 #define ULONG_MAX UINT_MAX
 
-#define LONG_LONG_MIN 0x8000000000000000LL
-#define LONG_LONG_MAX 0x7fffffffffffffffLL
+#define LONG_LONG_MIN  0x8000000000000000LL
+#define LONG_LONG_MAX  0x7fffffffffffffffLL
 #define ULONG_LONG_MAX 0xffffffffffffffffLL
-#define LLONG_MIN LONG_LONG_MIN
-#define LLONG_MAX LONG_LONG_MAX
-#define ULLONG_MAX ULONG_LONG_MAX
+#define LLONG_MIN      LONG_LONG_MIN
+#define LLONG_MAX      LONG_LONG_MAX
+#define ULLONG_MAX     ULONG_LONG_MAX
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN 256
-#define PATH_MAX 1024
-#define ARG_MAX 128
+#define PTHREAD_STACK_MIN  256
+#define PATH_MAX           1024
+#define ARG_MAX            128
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE
-#define PAGESIZE _PAGE_SIZE
+#define PAGESIZE  _PAGE_SIZE
 
 #endif

--- a/include/arch/ia32/limits.h
+++ b/include/arch/ia32/limits.h
@@ -51,7 +51,7 @@
 
 #define PTHREAD_STACK_MIN  256
 #define PATH_MAX           1024
-#define ARG_MAX            128
+#define ARG_MAX            32000
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE

--- a/include/arch/ia32/limits.h
+++ b/include/arch/ia32/limits.h
@@ -28,33 +28,33 @@
 
 #define MB_LEN_MAX 4
 
-#define SHRT_MIN -32768
-#define SHRT_MAX 32767
+#define SHRT_MIN  -32768
+#define SHRT_MAX  32767
 #define USHRT_MAX 65535
 
-#define INT_MIN -2147483648
-#define INT_MAX 0x7fffffff
+#define INT_MIN  -2147483648
+#define INT_MAX  0x7fffffff
 #define UINT_MAX 0xffffffff
 
-#define LONG_MIN INT_MIN
-#define LONG_MAX INT_MAX
+#define LONG_MIN  INT_MIN
+#define LONG_MAX  INT_MAX
 #define ULONG_MAX UINT_MAX
 
-#define LONG_LONG_MIN 0x8000000000000000LL
-#define LONG_LONG_MAX 0x7fffffffffffffffLL
+#define LONG_LONG_MIN  0x8000000000000000LL
+#define LONG_LONG_MAX  0x7fffffffffffffffLL
 #define ULONG_LONG_MAX 0xffffffffffffffffLL
-#define LLONG_MIN LONG_LONG_MIN
-#define LLONG_MAX LONG_LONG_MAX
-#define ULLONG_MAX ULONG_LONG_MAX
+#define LLONG_MIN      LONG_LONG_MIN
+#define LLONG_MAX      LONG_LONG_MAX
+#define ULLONG_MAX     ULONG_LONG_MAX
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN 256
-#define PATH_MAX 1024
-#define ARG_MAX 128
+#define PTHREAD_STACK_MIN  256
+#define PATH_MAX           1024
+#define ARG_MAX            128
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE
-#define PAGESIZE _PAGE_SIZE
+#define PAGESIZE  _PAGE_SIZE
 
 #endif

--- a/include/arch/riscv64/limits.h
+++ b/include/arch/riscv64/limits.h
@@ -51,7 +51,7 @@
 
 #define PTHREAD_STACK_MIN  256
 #define PATH_MAX           1024
-#define ARG_MAX            128
+#define ARG_MAX            32000
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE

--- a/include/arch/riscv64/limits.h
+++ b/include/arch/riscv64/limits.h
@@ -28,33 +28,33 @@
 
 #define MB_LEN_MAX 4
 
-#define SHRT_MIN -32768
-#define SHRT_MAX 32767
+#define SHRT_MIN  -32768
+#define SHRT_MAX  32767
 #define USHRT_MAX 65535
 
-#define INT_MIN -2147483648
-#define INT_MAX 0x7fffffff
+#define INT_MIN  -2147483648
+#define INT_MAX  0x7fffffff
 #define UINT_MAX 0xffffffff
 
-#define LONG_MIN 0x8000000000000000L
-#define LONG_MAX 0x7fffffffffffffffL
+#define LONG_MIN  0x8000000000000000L
+#define LONG_MAX  0x7fffffffffffffffL
 #define ULONG_MAX 0xffffffffffffffffL
 
-#define LONG_LONG_MIN LONG_MIN
-#define LONG_LONG_MAX LONG_MAX
+#define LONG_LONG_MIN  LONG_MIN
+#define LONG_LONG_MAX  LONG_MAX
 #define ULONG_LONG_MAX ULONG_MAX
-#define LLONG_MIN LONG_LONG_MIN
-#define LLONG_MAX LONG_LONG_MAX
-#define ULLONG_MAX ULONG_LONG_MAX
+#define LLONG_MIN      LONG_LONG_MIN
+#define LLONG_MAX      LONG_LONG_MAX
+#define ULLONG_MAX     ULONG_LONG_MAX
 
 #define SSIZE_MAX INT_MAX
 
-#define PTHREAD_STACK_MIN 256
-#define PATH_MAX 1024
-#define ARG_MAX 128
+#define PTHREAD_STACK_MIN  256
+#define PATH_MAX           1024
+#define ARG_MAX            128
 #define _POSIX2_RE_DUP_MAX 255
 
 #define PAGE_SIZE _PAGE_SIZE
-#define PAGESIZE _PAGE_SIZE
+#define PAGESIZE  _PAGE_SIZE
 
 #endif


### PR DESCRIPTION
JIRA: RTOS-59

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
-Increase ARG_MAX value for all targets
-apply clang-format for limits.h files
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Needed for running busybox's test suite (using busybox xargs causes displaying "can't fit single argument within argument list size limit" statement).
![Screenshot from 2021-07-07 14-48-49](https://user-images.githubusercontent.com/77304431/124769906-28c49080-df3a-11eb-84cb-ed9982129f05.png)

Because of SIZE_USTACK value for each target:
-ia32, riscv64, armv7a: (8 * SIZE_PAGE) = 32768
-armv7m: (3 * SIZE_PAGE) = 1536

New values of ARG_MAX are set to:
-32000 for arm-imx, ia32, riscv64
-1500 for armv7

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic - qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
