### PR TITLE
file: allocate stdin/stdout/stderr dynamically

### DIFF
--- a/stdio/file.c
+++ b/stdio/file.c
@@ -43,9 +43,6 @@ typedef struct {
 } popen_FILE;
 
 
-static FILE stdin_file  = {0, 0};
-static FILE stdout_file = {1, 0};
-static FILE stderr_file = {2, 0};
 FILE *stdin, *stdout, *stderr;
 
 
@@ -1009,9 +1006,13 @@ int pclose(FILE *file)
 
 void _file_init(void)
 {
-	stdin = &stdin_file;
-	stdout = &stdout_file;
-	stderr = &stderr_file;
+	stdin = calloc(1, sizeof(FILE));
+	stdout = calloc(1, sizeof(FILE));
+	stderr = calloc(1, sizeof(FILE));
+
+	stdin->fd = 0;
+	stdout->fd = 1;
+	stderr->fd = 2;
 
 	stdin->buffer = buffAlloc(BUFSIZ);
 	stdout->buffer = buffAlloc(BUFSIZ);


### PR DESCRIPTION
## Description

This makes `fclose(stdin)` possible which is needed by POSIX (eg. busybox
awk does that).

Fixes: phoenix-rtos/phoenix-rtos-project#133

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/33
- [x] Tested by hand on: `ia32-generic`, `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
