### PR TITLE
string: Fix bcopy() function header

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -161,7 +161,7 @@ extern int strverscmp(const char *s1, const char *s2);
 extern char *strsignal(int sig);
 
 
-__attribute__((always_inline)) static inline void bcopy(void *src, void *dest, size_t n)
+__attribute__((always_inline)) static inline void bcopy(const void *src, void *dest, size_t n)
 {
 	memmove(dest, src, n);
 }


### PR DESCRIPTION
According to the Open Group, src argument of bcopy shall be const.

JIRA: RTOS-71

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change makes bcopy() function header compliant to Open Group documentation:
https://pubs.opengroup.org/onlinepubs/007904875/functions/bcopy.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix is needed in order to eliminate compiler warnings, when trying to build e.g. mbedtls using our toolchain.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
