### PR TITLE
sys: setpriority/getpriority return value fix

### DIFF
--- a/sys/resource.c
+++ b/sys/resource.c
@@ -19,11 +19,18 @@
 
 int setpriority(int which, id_t who, int prio)
 {
-	return SET_ERRNO(priority(min(max(prio + 4, 0), 7)));
+	int ret = priority(min(max(prio + 4, 0), 7));
+	return SET_ERRNO(ret < 0 ? ret : 0);
 }
 
 
 int getpriority(int which, id_t who)
 {
-	return priority(-1) - 4;
+	int ret = priority(-1);
+	if (ret < 0) {
+		errno = -ret;
+		return -1;
+	}
+	else
+		return (ret - 4);
 }


### PR DESCRIPTION
setpriority returns negative value on error only

JIRA: DTR-92

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This fix is required for new -2 priority set to ps_dcu_app on DATARO. POSIX also specifies that setpriority() should return 0 on success.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
