### PR TITLE
arch: add missing architectures from gcc ARM multilib config

### DIFF
--- a/include/arch.h
+++ b/include/arch.h
@@ -1,8 +1,10 @@
 #if defined(__i386__) || defined(__x86_64__)
 #include <arch/ia32/arch.h>
-#elif defined(__ARM_ARCH_7A__)
+#elif defined(__ARM_ARCH_6M__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_BASE__) || defined(__ARM_ARCH_8M_MAIN__)
+#include <arch/armv7/arch.h>
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_8A__) || defined(__ARM_ARCH_7__)
 #include <arch/arm-imx/arch.h>
-#elif defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#elif defined(__ARM_ARCH_4T__) || defined(__ARM_ARCH_5TE__) /* not currently supported, map to 7M for libgcc to compile */
 #include <arch/armv7/arch.h>
 #elif defined(__riscv) && (__riscv_xlen == 64)
 #include <arch/riscv64/arch.h>


### PR DESCRIPTION
Fixes phoenix-rtos/phoenix-rtos-project#157

## Description
Needed for all variants of `libgcc` for ARM to build correctly (not fail in `./config` due to errors in headers).

Accidentally - brings `libstdc++` compilation much closer to completion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: hatifnat

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
