### PR TITLE
resolve_path: fix one letter leaf resolve

### DIFF
--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -156,8 +156,8 @@ static int _resolve_abspath(char *path, char *result, int resolve_last_symlink, 
 		}
 		else {
 			char *rem = slash;
-			while (*rem++ == '/')
-				;
+			while (*rem == '/')
+				rem++;
 			if (*rem == 0)
 				is_leaf = 1; /* trailing '/' */
 


### PR DESCRIPTION
JIRA: PD-160

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Change in `unistd/dir.c` in `resolve_path()` that fixes some issues with path resolving mainly:
 - one character missing leaf
 - path with missing branch (e.g `existing/missing/existing/file.txt`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is a byproduct of `psh` autocompletion PR: 
 - https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/78

`psh` tries to autocomplete path and filenames when `TAB` is used and path validation is done with `resolve_path()`. After changes to `resolve_path` problems occured with autocompletion in `psh`. During adapting `psh` to new `resolve_path()` two major flawes were found:
 - resolving path where missing leaf is one character long (e.g resolving path like: `b` or `bin/b`) resulted in wrong resolve
 - resolving paths where not a leaf, but part of branch is missing resulted in the whole path being resolved, while it would be logical to return `NULL` because path with missing branch cannot be resolved. **This needs to be discussed in this PR as `resolve_path` is Phoenix-RTOS specific**

Together with this change there is need for change in tests for `resolve_path()`:
 - https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/40

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] tests modified: (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/40).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/40)
- [ ] I will merge this PR by myself when appropriate.
