### PR TITLE
include/arch/riscv64: correct sizes from 32bit to 64bit

### DIFF
--- a/include/arch/riscv64/limits.h
+++ b/include/arch/riscv64/limits.h
@@ -47,7 +47,7 @@
 #define LLONG_MAX      LONG_LONG_MAX
 #define ULLONG_MAX     ULONG_LONG_MAX
 
-#define SSIZE_MAX INT_MAX
+#define SSIZE_MAX LONG_MAX
 
 #define PAGE_SIZE _PAGE_SIZE
 #define PAGESIZE  _PAGE_SIZE

--- a/include/arch/riscv64/stdint.h
+++ b/include/arch/riscv64/stdint.h
@@ -38,7 +38,7 @@ typedef int16_t int_fast16_t;
 typedef int32_t int_fast32_t;
 typedef int64_t int_fast64_t;
 
-#define UINT64_C(c) c ## UL
+#define UINT64_C(c) c##UL
 
 /* Define other fixed types along with defines/macros */
 
@@ -49,18 +49,18 @@ typedef int64_t int_fast64_t;
 typedef uint64_t uintmax_t;
 typedef int64_t intmax_t;
 
-#define INTMAX_MAX INT64_MAX
-#define INTMAX_MIN INT64_MIN
+#define INTMAX_MAX  INT64_MAX
+#define INTMAX_MIN  INT64_MIN
 #define UINTMAX_MAX UINT64_MAX
 
 typedef uint64_t uintptr_t;
 typedef int64_t intptr_t;
 
-#define INTPTR_MIN INT64_MIN
-#define INTPTR_MAX INT64_MAX
+#define INTPTR_MIN  INT64_MIN
+#define INTPTR_MAX  INT64_MAX
 #define UINTPTR_MAX UINT64_MAX
 
-#define _PRI_8 ""
+#define _PRI_8  ""
 #define _PRI_16 ""
 #define _PRI_32 ""
 #define _PRI_64 "l"

--- a/include/arch/riscv64/stdint.h
+++ b/include/arch/riscv64/stdint.h
@@ -38,13 +38,13 @@ typedef int16_t int_fast16_t;
 typedef int32_t int_fast32_t;
 typedef int64_t int_fast64_t;
 
-#define UINT64_C(c) c ## ULL
+#define UINT64_C(c) c ## UL
 
 /* Define other fixed types along with defines/macros */
 
 #define _USE_STANDARD_TYPES_STDINT
 
-#define SIZE_MAX UINT32_MAX
+#define SIZE_MAX UINT64_MAX
 
 typedef uint64_t uintmax_t;
 typedef int64_t intmax_t;
@@ -56,9 +56,9 @@ typedef int64_t intmax_t;
 typedef uint64_t uintptr_t;
 typedef int64_t intptr_t;
 
-#define INTPTR_MIN INT32_MIN
-#define INTPTR_MAX INT32_MAX
-#define UINTPTR_MAX UINT32_MAX
+#define INTPTR_MIN INT64_MIN
+#define INTPTR_MAX INT64_MAX
+#define UINTPTR_MAX UINT64_MAX
 
 #define _PRI_8 ""
 #define _PRI_16 ""


### PR DESCRIPTION
JIRA: RTOS-77

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- change pointer size for riscv64 targets from 32bit to 64 bit
- change size max to 64bit
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This removes warnings from phoenix-rtos-tests building (riscv64 targets)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
