### PR TITLE
malloc_dl: Free ptr, when size is equal to 0

### DIFF
--- a/stdlib/malloc_dl.c
+++ b/stdlib/malloc_dl.c
@@ -499,6 +499,11 @@ void *realloc(void *ptr, size_t size)
 	if (ptr == NULL)
 		return malloc(size);
 
+	if (size == 0) {
+		free(ptr);
+		return NULL;
+	}
+
 	if ((size + CHUNK_OVERHEAD) < size)
 		return NULL;
 


### PR DESCRIPTION
JIRA: RTOS-80

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change makes it possible to safely call realloc() with `size == 0` 0 and `ptr != NULL`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
According to [OpenGroup](https://pubs.opengroup.org/onlinepubs/009696899/functions/realloc.html), `realloc()` should in this case be equivalent to `free()`. This bug caused memory leakage in `getaddrinfo()` function.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
