### PR TITLE
strftime fix 0-paddings and add %y

### DIFF
--- a/time/time.c
+++ b/time/time.c
@@ -375,6 +375,9 @@ size_t strftime(char *restrict s, size_t maxsize, const char *restrict format, c
 			case 'Y':
 				res = snprintf(s + size, maxsize - size, "%u", 1900 + timeptr->tm_year);
 				break;
+			case 'y':
+				res = snprintf(s + size, maxsize - size, "%02u", timeptr->tm_year % 100);
+				break;
 			case 'Z':
 				c++;
 				continue;


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->
This PR contains two changes:
Padding %d, %j and %m with zeroes. If I didn't miss something  it's the only formats which require leading zereoes but dont have it.
Add %y format (two digits year withour century) 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was needed in SKAL project to print date in format %d-%m-%y %H:%M. I found that leading zeroes is not added but it should and %y is not supported. This change allowing me to print the date in desired format and make our sttftime more standard.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
This change can be breaking for those who rely on 1 digit %d, %j and %m. For now it will not be possible to achieve that with strftime. If someone need it, then should use another way or implement POSIX extention to strftime:

> An optional minimum field width. If the converted value, including any leading '+' or '-' sign, has fewer bytes than the minimum field width and the padding character is not the NUL character, the output shall be padded on the left (after any leading '+' or '-' sign) with the padding character

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, armv7m4-stm32l4x6).

It's covered by old tests. I compile test-strftime before and after my change. Diff from results below:

```
*** strftime1.txt       2021-08-26 12:21:51.297556206 +0200
--- strftime2.txt       2021-08-26 12:41:53.322112638 +0200
***************
*** 29,35 ****
  Return 14 Expected: 16
  Format string "%6d %3d %2d %d"
! Output string "%6d %3d %2d 2"
  Expected      "000002 002 02 02"
! Return 13 Expected: 16
  Format string "%D %12D %012D"
  Output string "%D %12D %012D"
--- 29,35 ----
  Return 14 Expected: 16
  Format string "%6d %3d %2d %d"
! Output string "%6d %3d %2d 02"
  Expected      "000002 002 02 02"
! Return 14 Expected: 16
  Format string "%D %12D %012D"
  Output string "%D %12D %012D"
***************
*** 113,117 ****
  Return 5 Expected: 17
  Format string "%y %05y %Y %05Y"
! Output string "%y %05y 1995 %05Y"
  Expected      "95 00095 1995 01995"
  Return 17 Expected: 19
--- 113,117 ----
  Return 5 Expected: 17
  Format string "%y %05y %Y %05Y"
! Output string "95 %05y 1995 %05Y"
  Expected      "95 00095 1995 01995"
  Return 17 Expected: 19

```

Also I run my project to just check if date is now valid.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
