### PR TITLE
unistd/pwd: change getpwuid()/getpwnam() functions

### DIFF
--- a/unistd/pwd.c
+++ b/unistd/pwd.c
@@ -5,14 +5,15 @@
  *
  * Password related functions
  *
- * Copyright 2018 Phoenix Systems
- * Author: Jan Sikorski
+ * Copyright 2018, 2021 Phoenix Systems
+ * Author: Jan Sikorski, Mateusz Niewiadomski
  *
  * This file is part of Phoenix-RTOS.
  *
  * %LICENSE%
  */
 
+#include <ctype.h>
 #include <pwd.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -24,69 +25,108 @@
 
 struct passwd pwnam;
 char pw_name[NAME_MAX];
+char intstr[16];
 char pw_gecos[128];
 char pw_dir[PATH_MAX];
 char pw_shell[PATH_MAX];
 char pw_passwd[128];
 
 
-struct passwd *getpwnam(const char *name)
+static int readpwentry(FILE *fp, char *pwentry, unsigned int maxlen, unsigned int islast)
 {
-	FILE *fp;
-	char buf[1024];
+	int c = 0;
+	unsigned int i = 0, isbad = 0;
 
-	if ((fp = fopen(PASSWD_PATH, "r")) == NULL)
-		return NULL;
+	do {
+		c = fgetc(fp);
+		if (c == ':' || c == '\n' || c == EOF)
+			break;
 
-	pwnam.pw_name = pw_name;
-	pwnam.pw_gecos = pw_name;
-	pwnam.pw_dir = pw_dir;
-	pwnam.pw_gecos = pw_gecos;
-	pwnam.pw_shell = pw_shell;
-	pwnam.pw_passwd = pw_passwd;
+		if (i < maxlen - 1)
+			pwentry[i++] = c;
+		else
+			isbad = 1;
+	} while (!isbad);
+	pwentry[i] = '\0';
 
-	while (fgets(buf, sizeof(buf), fp)) {
-		sscanf (buf, "%[^:]:%[^:]:%d:%d:%[^:]:%[^:]:%s\n",
-			pwnam.pw_name, pwnam.pw_passwd,
-			&pwnam.pw_uid, &pwnam.pw_gid,
-			pwnam.pw_gecos, pwnam.pw_dir, pwnam.pw_shell);
-		if (strcmp(pwnam.pw_name, name) == 0) {
-			fclose(fp);
-			return &pwnam;
+	if ((c == EOF || c == '\n') && !islast)
+		isbad = 1;
+
+	return isbad;
+}
+
+
+static inline int readuid(int readpwentry, uid_t *uid)
+{
+	int i, err = readpwentry;
+	*uid = strtoul(intstr, NULL, 10);
+
+	if (readpwentry == 0) {
+		for (i = 0; intstr[i] != '\0'; ++i) {
+			if (!isdigit(intstr[i])) {
+				err = 1;
+				break;
+			}
 		}
 	}
-	fclose(fp);
-	return NULL;
+
+	return err;
+}
+
+
+static struct passwd *getpwby(const char *name, uid_t *uid)
+{
+	struct passwd *retpwnam = NULL;
+	FILE *fp = fopen(PASSWD_PATH, "r");
+
+	if (fp != NULL) {
+		pwnam.pw_name = pw_name;
+		pwnam.pw_dir = pw_dir;
+		pwnam.pw_gecos = pw_gecos;
+		pwnam.pw_shell = pw_shell;
+		pwnam.pw_passwd = pw_passwd;
+
+		do {
+			if (readpwentry(fp, pwnam.pw_name, NAME_MAX, 0))
+				break;
+			if (readpwentry(fp, pwnam.pw_passwd, sizeof(pw_passwd), 0))
+				break;
+			if (readuid(readpwentry(fp, intstr, sizeof(intstr), 0), &pwnam.pw_uid))
+				break;
+			if (readuid(readpwentry(fp, intstr, sizeof(intstr), 0), &pwnam.pw_gid))
+				break;
+			if (readpwentry(fp, pwnam.pw_gecos, sizeof(pw_gecos), 0))
+				break;
+			if (readpwentry(fp, pwnam.pw_dir, PATH_MAX, 0))
+				break;
+			if (readpwentry(fp, pwnam.pw_shell, PATH_MAX, 1))
+				break;
+
+			if (name != NULL && strcmp(pwnam.pw_name, name) == 0) {
+				retpwnam = &pwnam;
+				break;
+			}
+			else if (uid != NULL && pwnam.pw_uid == *uid) {
+				retpwnam = &pwnam;
+				break;
+			}
+		} while (!feof(fp));
+
+		fclose(fp);
+	}
+	return retpwnam;
+}
+
+
+struct passwd *getpwnam(const char *name)
+{
+	return (name == NULL) ? NULL : getpwby(name, NULL);
 }
 
 
 struct passwd *getpwuid(uid_t uid)
 {
-	FILE *fp;
-	char buf[1024];
-
-	if ((fp = fopen(PASSWD_PATH, "r")) == NULL)
-		return NULL;
-
-	pwnam.pw_name = pw_name;
-	pwnam.pw_gecos = pw_name;
-	pwnam.pw_dir = pw_dir;
-	pwnam.pw_gecos = pw_gecos;
-	pwnam.pw_shell = pw_shell;
-	pwnam.pw_passwd = pw_passwd;
-
-	while (fgets(buf, sizeof(buf), fp)) {
-		sscanf (buf, "%[^:]:%[^:]:%d:%d:%[^:]:%[^:]:%s\n",
-			pwnam.pw_name, pwnam.pw_passwd,
-			&pwnam.pw_uid, &pwnam.pw_gid,
-			pwnam.pw_gecos, pwnam.pw_dir, pwnam.pw_shell);
-		if (pwnam.pw_uid == uid) {
-			fclose(fp);
-			return &pwnam;
-		}
-	}
-	fclose(fp);
-	return NULL;
+	return getpwby(NULL, &uid);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changes to `getpwuid` and `getpwnam` functions because of their poor form.  Changes:
 - merged common operations into `getpwby()` and `getpwEntry()` static functions
   -  char by char reading of `/etc/passwd` instead of broken scanf
   - get rid of buffer and reading directly into `struct passwd pwnam`
   - no buffer overflow risk
-  check for edge case of function call: `getpnam(NULL);`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Main goal was to reduce stack memory usage and overall fix of memory usage as current implementation is prone to crash. The buffer used to store user entry was too small and using `getpwnam`or `getpwuid` on entry with maxed out (by length) fields will result in not reading all the data. For small targets the stack size is about 4kB and getpwuid by itself must use at least 2,5kB (result of `PATH_MAX`-sized fields) so the solution without additional buffer is necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added:
  - https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/50
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
