### PR TITLE
unistd: make _readlink_abs ask for file not device

### DIFF
--- a/stdio/file.c
+++ b/stdio/file.c
@@ -1076,7 +1076,7 @@ FILE *tmpfile(void)
 {
 	oid_t oid;
 
-	while (lookup("/dev/posix/tmpfile", NULL, &oid) < 0) {
+	while (lookup("/dev/posix/tmpfile", &oid, NULL) < 0) {
 		if (errno != EINTR)
 			return NULL;
 	}

--- a/stdlib/mktemp.c
+++ b/stdlib/mktemp.c
@@ -53,7 +53,7 @@ static int mktemp(char *template, int suffixlen)
 
 	close(fd);
 
-	if (lookup(template, NULL, &oid) == EOK)
+	if (lookup(template, &oid, NULL) == EOK)
 		return -EEXIST;
 
 	return EOK;

--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -375,7 +375,7 @@ DIR *opendir(const char *dirname)
 		return NULL; /* errno set by resolve_path */
 	}
 
-	if (!dirname[0] || (safe_lookup(canonical_name, NULL, &s->oid) < 0)) {
+	if (!dirname[0] || (safe_lookup(canonical_name, &s->oid, NULL) < 0)) {
 		free(canonical_name);
 		free(s);
 		errno = ENOENT;
@@ -453,7 +453,7 @@ static ssize_t _readlink_abs(const char *path, char *buf, size_t bufsiz)
 
 	assert(path && path[0] == '/');
 
-	if ((ret = safe_lookup(path, NULL, &oid)) < 0)
+	if ((ret = safe_lookup(path, &oid, NULL)) < 0)
 		return SET_ERRNO(ret);
 
 	msg.type = mtGetAttr;
@@ -517,7 +517,7 @@ int rmdir(const char *path)
 
 	splitname(canonical_name, &name, &dirname);
 
-	if (safe_lookup(dirname, NULL, &dir)) {
+	if (safe_lookup(dirname, &dir, NULL)) {
 		free(canonical_name);
 		return SET_ERRNO(-ENOENT);
 	}

--- a/unistd/file.c
+++ b/unistd/file.c
@@ -169,7 +169,7 @@ int symlink(const char *target, const char *linkpath)
 
 	splitname(canonical_linkpath, &name, &dir_name);
 
-	if ((ret = lookup(dir_name, NULL, &dir)) < 0) {
+	if ((ret = lookup(dir_name, &dir, NULL)) < 0) {
 		free(canonical_linkpath);
 		return SET_ERRNO(ret);
 	}


### PR DESCRIPTION
JIRA: BES-187

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixing a situation where during stat() we ask a link whether it is a link. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
