### PR TITLE
sys/types.h: change blkcnt_t type to long long

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -35,7 +35,7 @@ typedef int dev_t;
 typedef int ino_t;
 typedef int nlink_t;
 typedef int blksize_t;
-typedef int blkcnt_t;
+typedef long long blkcnt_t;
 typedef long long off64_t;
 typedef off64_t off_t;
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Storage device with 512-byte block size and >256GB of storage capacity couldn't be properly represented with `blkcnt_t` and `blksize_t` types.
[JIRA: RTOS-117](https://jira.phoenix-rtos.com/browse/RTOS-117)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic, armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/247
- [ ] I will merge this PR by myself when appropriate.
