### PR TITLE
syslog: Allow LOG_KERN facility

### DIFF
--- a/syslog/syslog.c
+++ b/syslog/syslog.c
@@ -38,6 +38,7 @@ static struct {
 	int logmask;
 	int logopt;
 	int facility;
+	int configured;
 
 	struct sockaddr_un addr;
 	socklen_t addrlen;
@@ -75,9 +76,10 @@ void openlog(const char *ident, int logopt, int facility)
 		}
 	}
 
+	syslog_common.configured = 1;
 	syslog_common.logmask = 0;
 	syslog_common.logopt = logopt;
-	syslog_common.facility = (facility > 0) ? facility : LOG_USER;
+	syslog_common.facility = facility;
 }
 
 
@@ -101,7 +103,7 @@ void vsyslog(int priority, const char *format, va_list ap)
 		return;
 
 	if (!syslog_common.open)
-		openlog(syslog_common.ident, syslog_common.logopt | LOG_NDELAY, syslog_common.facility);
+		openlog(syslog_common.ident, syslog_common.logopt | LOG_NDELAY, syslog_common.configured ? syslog_common.facility : LOG_USER);
 
 	if (LOG_FAC(priority) == 0)
 		priority |= syslog_common.facility;


### PR DESCRIPTION

## Description
LOG_USR should be a default facility, if a user has not previously
called openlog().

JIRA: DTR-3
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is neede in order to allow applications like klogd to correctly use syslog() with LOG_KERN facility.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
