### PR TITLE
socket: remove custom SOCK_LARGEBUF flag

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -29,7 +29,6 @@
 #define EPROTO          71
 #define EBADMSG         74
 #define EMSGSIZE        90
-#define ENOPROTOOPT     92
 #define EPFNOSUPPORT    96
 #define EADDRNOTAVAIL   99
 #define ENETDOWN        100

--- a/include/sys/sockdefs.h
+++ b/include/sys/sockdefs.h
@@ -18,6 +18,5 @@
 
 #define SOCK_NONBLOCK 0x8000
 #define SOCK_CLOEXEC  0x4000
-#define SOCK_LARGEBUF 0x2000
 
 #endif


### PR DESCRIPTION
DONE: DTR-209

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/280
https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/32

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
