### PR TITLE
libphoenix/unistd: redundant declarations of `getlogin()` and `issetugid`

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -222,12 +222,6 @@ extern pid_t setsid(void);
 extern pid_t getsid(pid_t pid);
 
 
-extern int issetugid(void);
-
-
-extern char *getlogin(void);
-
-
 extern int gethostname(char *name, size_t namelen);
 
 


### PR DESCRIPTION
JIRA: CI-100

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Nitpick, removing redundant declarations of `getlogin()` and `issetugid`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/279

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
