### PR TITLE
umask: don't restrict process file mode mask until proper implementation is added

### DIFF
--- a/sys/stat.c
+++ b/sys/stat.c
@@ -115,7 +115,9 @@ int stat(const char *path, struct stat *buf)
 
 mode_t umask(mode_t cmask)
 {
-	return -ENOSYS;
+	/* TODO: add proper umask() implementation */
+	/* Don't restrict process file mode mask for now */
+	return 0;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`umask()` can't fail, return 0 not to restrict any permission attributes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-206](https://jira.phoenix-rtos.com/browse/DTR-206)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic, armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
