### PR TITLE
unistd/stdio: `resolve_path()`, `fopen()` and `open()` errno fixes

### DIFF
--- a/stdio/file.c
+++ b/stdio/file.c
@@ -184,8 +184,10 @@ FILE *fopen(const char *filename, const char *mode)
 	FILE *f;
 	int fd;
 
-	if (filename == NULL || mode == NULL)
+	if (mode == NULL) {
+		errno = EINVAL;
 		return NULL;
+	}
 
 	if ((m = string2mode(mode)) < 0)
 		return NULL;

--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -270,8 +270,13 @@ char *resolve_path(const char *path, char *resolved_path, int resolve_last_symli
 	char *path_copy, *p;
 	size_t pathlen;
 
-	if (!path || !path[0]) {
-		errno = (!path) ? EINVAL : ENOENT;
+	if (!path) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (!path[0]) {
+		errno = ENOENT;
 		return NULL;
 	}
 

--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -271,7 +271,7 @@ char *resolve_path(const char *path, char *resolved_path, int resolve_last_symli
 	size_t pathlen;
 
 	if (!path || !path[0]) {
-		errno = EINVAL;
+		errno = (!path) ? EINVAL : ENOENT;
 		return NULL;
 	}
 

--- a/unistd/file.c
+++ b/unistd/file.c
@@ -120,9 +120,9 @@ int open(const char *filename, int oflag, ...)
 	mode = va_arg(ap, mode_t);
 	va_end(ap);
 
-	if (oflag & (O_WRONLY | O_RDWR | O_RDONLY)) {
+	if (oflag & (O_WRONLY | O_RDWR)) {
 		if ((err = stat(filename, &st)) < 0) {
-			if (errno != ENOENT || (oflag & O_RDONLY))
+			if (errno != ENOENT)
 				return err;
 		}
 		else if (S_ISDIR(st.st_mode)) {

--- a/unistd/file.c
+++ b/unistd/file.c
@@ -120,9 +120,9 @@ int open(const char *filename, int oflag, ...)
 	mode = va_arg(ap, mode_t);
 	va_end(ap);
 
-	if (oflag & (O_WRONLY | O_RDWR)) {
+	if (oflag & (O_WRONLY | O_RDWR | O_RDONLY)) {
 		if ((err = stat(filename, &st)) < 0) {
-			if (errno != ENOENT)
+			if (errno != ENOENT || (oflag & O_RDONLY))
 				return err;
 		}
 		else if (S_ISDIR(st.st_mode)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - corrections in errno returned from `resolve_path()` with compliance to posix `resolve()` function
 - ~~corrections in errno returned from `open()` with compliance to posix~~ **DROPPED**
 - corrections in errno returning from `fopen()` with compliance to posix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - Changes in `resolve_path()` for accordance with documentation:
> The realpath() function shall fail if:
    (...)
    [EINVAL] The file_name argument is a null pointer.
    (...)
    [ENOENT] A component of file_name does not name an existing file or file_name points to an empty string.

 - ~~Add handling of `path = ""` in `open()` for accordance with:~~ **DROPPED**
> ~~open() shall fall if:
    [ENOENT] O_CREAT is not set and a component of path does not name an existing file, or O_CREAT is set and a component of the path prefix of path does not name an existing file, **or path points to an empty string**.~~

 - Removed `path == NULL` check in `fopen()` (it is checked in `resolve_path()` later on) for accordance with:
> The fopen() function may fail if:
    [EINVAL] The value of the mode argument is not valid. 
    (...)
    [ENOENT] The mode string begins with 'r' and a component of pathname does not name an existing file, or mode begins with 'w' or 'a' and a component of the path prefix of pathname does not name an existing file, or pathname is an empty string. 
    

Related issues:
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/256
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/287
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/288
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/296

**Note:** not all issues mentioned above will be fully solved by this change as some issues are collections of multiple ones found.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia-32 generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
