### PR TITLE
sys/stat.h: add ALLPERMS and ACCESSPERMS macros, clean up file type and permission macros

### DIFF
--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -20,52 +20,55 @@
 #include <time.h>
 
 
-#define S_ISUID 0004000   /* set user id on execution */
-#define S_ISGID 0002000   /* set group id on execution */
-#define S_ISTXT 0001000   /* sticky bit */
+/* File type */
+#define S_IFMT   0xf000 /* File type mask */
+#define S_IFSOCK 0xc000 /* Socket */
+#define S_IFLNK  0xa000 /* Symbolic link */
+#define S_IFREG  0x8000 /* Regular file */
+#define S_IFBLK  0x6000 /* Block device */
+#define S_IFDIR  0x4000 /* Directory */
+#define S_IFCHR  0x2000 /* Character device */
+#define S_IFIFO  0x1000 /* FIFO */
 
-#define S_IRWXU 0000700   /* RWX mask for owner */
-#define S_IRUSR 0000400   /* R for owner */
-#define S_IWUSR 0000200   /* W for owner */
-#define S_IXUSR 0000100   /* X for owner */
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK) /* Socket */
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)  /* Symbolic link */
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)  /* Regular file */
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)  /* Block device */
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)  /* Directory */
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)  /* Character device */
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)  /* FIFO */
 
-#define S_IREAD   S_IRUSR
-#define S_IWRITE  S_IWUSR
-#define S_IEXEC   S_IXUSR
+/* File permissions */
+#define S_ISUID 0x0800 /* Set user ID on execution */
+#define S_ISGID 0x0400 /* Set group ID on execution */
+#define S_ISVTX 0x0200 /* Sticky bit */
 
-#define S_IRWXG 0000070   /* RWX mask for group */
-#define S_IRGRP 0000040   /* R for group */
-#define S_IWGRP 0000020   /* W for group */
-#define S_IXGRP 0000010   /* X for group */
+#define S_IRWXU 0x01c0 /* RWX mask for owner */
+#define S_IRUSR 0x0100 /* R for owner */
+#define S_IWUSR 0x0080 /* W for owner */
+#define S_IXUSR 0x0040 /* X for owner */
 
-#define S_IRWXO 0000007   /* RWX mask for other */
-#define S_IROTH 0000004   /* R for other */
-#define S_IWOTH 0000002   /* W for other */
-#define S_IXOTH 0000001   /* X for other */
+#define S_IRWXG 0x0038 /* RWX mask for group */
+#define S_IRGRP 0x0020 /* R for group */
+#define S_IWGRP 0x0010 /* W for group */
+#define S_IXGRP 0x0008 /* X for group */
 
-#define S_IFMT   0xF000   /* mask for type */
-#define S_IFSOCK 0xC000   /* socket */
-#define S_IFLNK  0xA000   /* symbolic link */
-#define S_IFREG  0x8000   /* regular file */
-#define S_IFBLK  0x6000   /* block device */
-#define S_IFDIR  0x4000   /* directory */
-#define S_IFCHR  0x2000   /* character device */
-#define S_IFIFO  0x1000   /* fifo */
+#define S_IRWXO 0x0007 /* RWX mask for other */
+#define S_IROTH 0x0004 /* R for other */
+#define S_IWOTH 0x0002 /* W for other */
+#define S_IXOTH 0x0001 /* X for other */
 
-#define S_ISVTX  0001000  /* save swapped text even after use */
+/* BSD compatibility macros */
+#define S_ISTXT  S_ISVTX
+#define S_IREAD  S_IRUSR
+#define S_IWRITE S_IWUSR
+#define S_IEXEC  S_IXUSR
 
-#define S_BLKSIZE  512  /* block size used in the stat struct */
+#define S_BLKSIZE 512 /* Block size (stat.st_blocks unit) */
 
-/* 0666 */
-#define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
-
-#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)  /* directory */
-#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)  /* char special */
-#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)  /* block special */
-#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)  /* regular file */
-#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)  /* fifo */
-#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)  /* symbolic link */
-#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK) /* socket */
+#define ALLPERMS    (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)                               /* 0777 */
+#define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) /* 0666 */
 
 
 typedef int dev_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added `ALLPERMS` and `ACCESSPERMS` macros (the names are taken from BSD: [link](https://github.com/openbsd/src/blob/4cd1828ed9eeebb6486d183eb7e4a99fc9464b70/sys/sys/stat.h#L151-L153))
Cleaned up file type and permission bits macros (removed octal notation in favour of hexedecimal).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code that manages file permissions should use provided macros instead of 'magic values', e.g. 0777.
[JIRA: RTOS-148](https://jira.phoenix-rtos.com/browse/RTOS-148)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/288
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/59
- [ ] I will merge this PR by myself when appropriate.
