### PR TITLE
fixing errno of `rmdir()` and `chdir()` when not called on a directory

### DIFF
--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -521,9 +521,20 @@ int rmdir(const char *path)
 	msg_t msg = { 0 };
 	oid_t dir, dev;
 	char *canonical_name, *dirname, *name;
+	struct stat s;
 
 	if ((canonical_name = resolve_path(path, NULL, 1, 0)) == NULL)
 		return -1; /* errno set by resolve_path */
+
+	if (stat(canonical_name, &s) < 0) {
+		free(canonical_name);
+		return SET_ERRNO(-ENOENT);
+	}
+
+	if (!S_ISDIR(s.st_mode)) {
+		free(canonical_name);
+		return SET_ERRNO(-ENOTDIR);
+	}
 
 	if (safe_lookup(canonical_name, &dir, &dev)) {
 		free(canonical_name);

--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -56,9 +56,14 @@ int chdir(const char *path)
 	if ((canonical = resolve_path(path, NULL, 1, 0)) == NULL)
 		return -1; /* errno set by resolve_path */
 
-	if (stat(canonical, &s) < 0 || !S_ISDIR(s.st_mode)) {
+	if (stat(canonical, &s) < 0) {
 		free(canonical);
 		return SET_ERRNO(-ENOENT);
+	}
+
+	if (!S_ISDIR(s.st_mode)) {
+		free(canonical);
+		return SET_ERRNO(-ENOTDIR);
 	}
 
 	/* TODO:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changes fixing:
 - errno returned by `rmdir()` when not called on directory
 - errno returned by `chdir()` when not called on directory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/287
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/288


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
