### PR TITLE
string: add strlcat() and strlcpy() implementation

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -93,6 +93,14 @@ extern char *stpcpy(char *dest, const char *src);
 extern char *strncpy(char *dest, const char *src, size_t n);
 
 
+/*  copies up to size - 1 characters from the NUL-terminated string src to dst, NUL-terminating the result */
+extern size_t strlcpy(char *dst, const char *src, size_t size);
+
+
+/* appends the NUL-terminated string src to the end of dst. It will append at most size - strlen(dst) - 1 bytes, NUL-terminating the result. */
+extern size_t strlcat(char *dst, const char *src, size_t size);
+
+
 /* Calculates the length of the initial segment of str1 which consists entirely of characters not in str2. */
 extern size_t strcspn(const char *str1, const char *str2);
 

--- a/string/string.c
+++ b/string/string.c
@@ -5,8 +5,8 @@
  *
  * string/string (generic implementation of string functions)
  *
- * Copyright 2017 Phoenix Systems
- * Author: Pawel Pisarczyk
+ * Copyright 2017, 2022 Phoenix Systems
+ * Author: Pawel Pisarczyk, Mateusz Niewiadomski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -459,4 +459,31 @@ char *strncat(char *dest, const char *src, size_t n)
 	dest[len + i] = '\0';
 
 	return dest;
+}
+
+
+size_t strlcpy(char *dst, const char *src, size_t size)
+{
+	size_t len = 0;
+
+	if (size) {
+		while (--size && *src) {
+			*(dst++) = *(src++);
+			len++;
+		}
+		*dst = '\0';
+	}
+
+	while (*(src++))
+		len++;
+	return len;
+}
+
+
+size_t strlcat(char *dst, const char *src, size_t size)
+{
+	size_t dstlen = strnlen(dst, size);
+	if (dstlen == size)
+		return size + strlen(src);
+	return dstlen + strlcpy(dst + dstlen, src, size - dstlen);
 }


### PR DESCRIPTION
JIRA: PD-189

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Two functions that are BSD-based: `strlcpy()` and `strlcat()` implemented in libphoenix for better micropython port compatibility. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Phoenix-RTOS supports micropython port which internally uses both `strlcpy()` and `strlcat()` functions. Their source code is artificially added do codebase via patches. This PR aims to reduce patches by implementing these functions in libphoenix.

`strlcpy()` and `strlcat()` short description:

> The strlcpy() and strlcat() functions copy and concatenate strings respectively. They are designed to be safer, more consistent, and less error prone replacements for strncpy(3) and strncat(3). Unlike those functions, strlcpy() and strlcat() take the full size of the buffer (not just the length) and guarantee to NUL-terminate the result (as long as size is larger than 0 or, in the case of strlcat(), as long as there is at least one byte free in dst). Note that a byte for the NUL should be included in size.

Full description: https://linux.die.net/man/3/strlcpy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/54).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
