### PR TITLE
unistd/dir: fix readdir(), when reading file with NAME_MAX name length

### DIFF
--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -344,7 +344,7 @@ struct dirent *readdir(DIR *s)
 	memset(&msg, 0, sizeof(msg));
 
 	if (s->dirent == NULL) {
-		if ((s->dirent = calloc(1, sizeof(struct dirent) + NAME_MAX)) == NULL)
+		if ((s->dirent = calloc(1, sizeof(struct dirent) + NAME_MAX + 1)) == NULL)
 			return NULL;
 	}
 
@@ -353,7 +353,7 @@ struct dirent *readdir(DIR *s)
 
 	memcpy(&msg.i.readdir.dir, &s->oid, sizeof(oid_t));
 	msg.o.data = s->dirent;
-	msg.o.size = sizeof(struct dirent) + NAME_MAX;
+	msg.o.size = sizeof(struct dirent) + NAME_MAX + 1;
 
 	if (msgSend(s->oid.port, &msg) < 0) {
 		free(s->dirent);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- unistd/dir: fix readdir(), when reading file with NAME_MAX name length

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes: phoenix-rtos/phoenix-rtos-project#397

DONE: RTOS-125

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m7-imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
