### PR TITLE
- stdlib: strtol: correct return type in definitions

### DIFF
--- a/stdlib/strtoul.c
+++ b/stdlib/strtoul.c
@@ -17,9 +17,9 @@
 #include "ctype.h"
 
 
-unsigned int strtoul(char *nptr, char **endptr, int base)
+unsigned long int strtoul(char *nptr, char **endptr, int base)
 {
-	unsigned int t, v = 0;
+	unsigned long int t, v = 0;
 
 	if ((base == 16 || base == 0) && nptr[0] == '0' && (nptr[1] | 0x20) == 'x') {
 		base = 16;
@@ -34,7 +34,7 @@ unsigned int strtoul(char *nptr, char **endptr, int base)
 		if (t > 9)
 			t = (*nptr | 0x20) - 'a' + 10;
 
-		if (t >= (unsigned int)base)
+		if (t >= (unsigned long int)base)
 			break;
 
 		v = (v * base) + t;
@@ -47,9 +47,9 @@ unsigned int strtoul(char *nptr, char **endptr, int base)
 }
 
 
-int strtol(char *nptr, char **endptr, int base)
+long int strtol(char *nptr, char **endptr, int base)
 {
-	int sign = 1;
+	long int sign = 1;
 
 	if (*nptr == '-') {
 		sign = -1;
@@ -62,11 +62,11 @@ int strtol(char *nptr, char **endptr, int base)
 
 int atoi(char *str)
 {
-	return strtol(str, NULL, 10);
+	return (int)strtol(str, NULL, 10);
 }
 
 
-int atol(char *str)
+long int atol(char *str)
 {
 	return strtol(str, NULL, 10);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- stdlib: strtol: change return type to long int from int

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- `strtol()`, `strtoul()` definitions incompatible with declarations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
