### PR TITLE
string: Fix strncmp() and strncasecmp()

### DIFF
--- a/string/string.c
+++ b/string/string.c
@@ -86,6 +86,10 @@ int strncasecmp(const char *s1, const char *s2, size_t n)
 			return 1;
 	}
 
+	if (k < n && (tolower(*p) != tolower(*(s2 + k)))) {
+		return -1;
+	}
+
 	return 0;
 }
 #endif
@@ -103,6 +107,10 @@ int strncmp(const char *s1, const char *s2, size_t n)
 			return -1;
 		else if (*p > *(s2 + k))
 			return 1;
+	}
+
+	if (k < n && (*p != *(s2 + k))) {
+		return -1;
 	}
 
 	return 0;


### PR DESCRIPTION
Currently both functions always return 0, if the first argument is
an empty string. We need to handle the case, when the for loop has
been finished before comparing all 'n' characters.

JIRA: RTOS-193

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
