### PR TITLE
pthread: fix missing stack free after thread join

### DIFF
--- a/pthread/pthread.c
+++ b/pthread/pthread.c
@@ -30,6 +30,8 @@ typedef struct pthread_ctx {
 	void *(*start_routine)(void *);
 	void *arg;
 	void *retval;
+	void *stack;
+	size_t stacksize;
 	struct pthread_ctx *next;
 	struct pthread_ctx *prev;
 	int detached;
@@ -103,6 +105,8 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
 	ctx->detached = attrs->detached;
 	ctx->start_routine = start_routine;
 	ctx->arg = arg;
+	ctx->stack = stack;
+	ctx->stacksize = attrs->stacksize;
 	*thread = (pthread_t)ctx;
 
 	int err = beginthreadex(start_point, attrs->priority, stack,
@@ -157,6 +161,7 @@ int pthread_join(pthread_t thread, void **value_ptr)
 	_errno_remove(&ctx->e);
 
 	LIST_REMOVE(&pthread_list, ctx);
+	munmap(ctx->stack, ctx->stacksize);
 	free(ctx);
 
 	return EOK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- Fixes stack memory leak after pthread_join

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: RTOS-205

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
