### PR TITLE
malloc: let malloc set errno

### DIFF
--- a/stdlib/malloc_trivial3.c
+++ b/stdlib/malloc_trivial3.c
@@ -143,6 +143,10 @@ void *malloc(size_t size)
 	m = _malloc_heapAlloc(size);
 	mutexUnlock(malloc_common.mutex);
 
+	if (m == NULL) {
+		errno = ENOMEM;
+	}
+
 	return m;
 }
 


### PR DESCRIPTION
SUSv2 requires `malloc()`, `calloc()`, and `realloc()` to set `errno` to `ENOMEM` upon failure. Applications that check `errno`
on a `NULL` result without setting this value behave unexpectedly.

JIRA: RTOS-222

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176-evk, ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
