### PR TITLE
unistd: fix _SC_OPEN_MAX value returned by sysconf()

### DIFF
--- a/unistd/sysconf.c
+++ b/unistd/sysconf.c
@@ -22,7 +22,9 @@ long sysconf(int name)
 {
 	switch (name) {
 	case _SC_OPEN_MAX:
-		return (1u << 31) - 1;
+		/* value got from MAX_FD_COUNT (kernel) */
+		/* TODO: come up with a solution to access a macro defined in kernel posix module */
+		return 512;
 	case _SC_IOV_MAX:
 		return IOV_MAX;
 	default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - unistd: fix _SC_OPEN_MAX value returned by sysconf()
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

DONE: RTOS-240

Required for running posix test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
