### PR TITLE
pthread_join: call threadJoin with specific id

### DIFF
--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -60,7 +60,7 @@ extern int exec(const char *path, char *const argv[], char *const env[]);
 extern int spawnSyspage(const char *imap, const char *dmap, const char *name, char *const argv[]);
 
 
-extern int threadJoin(time_t timeout);
+extern int threadJoin(int tid, time_t timeout);
 
 
 extern int beginthreadex(void (*start)(void *), unsigned int priority, void *stack, unsigned int stacksz, void *arg, handle_t *id);


### PR DESCRIPTION
JIRA: RTOS-226

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`pthread_join` now calls threadJoin with specific thread id

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: RTOS-226
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/342.
- [ ] I will merge this PR by myself when appropriate.
