### PR TITLE
unistd: fix getopt -- case

### DIFF
--- a/unistd/getopt.c
+++ b/unistd/getopt.c
@@ -41,7 +41,6 @@ int getopt(int argc, char * const argv[], const char *optstring)
 		return -1;
 
 	if (argv[optind][1] == '-') {
-		optind++;
 		return -1;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - unistd: fix getopt -- case

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - According to POSIX getopt shall return -1 without changing optind, when argv[optind] points to '--'

 - JIRA: PD-303

 - Before this change calling some psh commands with `--` arg, like `history --x` or `mem --` had no effect (not even error message)
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (test-getopt updated: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/138).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/138).
- [ ] I will merge this PR by myself when appropriate.
