### PR TITLE
unistd/getopt.c: fix getopt() function

### DIFF
--- a/unistd/getopt.c
+++ b/unistd/getopt.c
@@ -34,13 +34,18 @@ int getopt(int argc, char * const argv[], const char *optstring)
 	char *optspec;
 	int leading_colon;
 
+	if (optind <= 0) {
+		optind = 1;
+		optwhere = 1;
+	}
+
 	if (argc == 0 || argv == NULL || optind >= argc)
 		return -1;
 
 	if (argv[optind] == NULL || argv[optind][0] != '-' || argv[optind][1] == '\0')
 		return -1;
 
-	if (argv[optind][1] == '-') {
+	if ((argv[optind][1] == '-') && (argv[optind][2] == '\0')) {
 		optind++;
 		return -1;
 	}


### PR DESCRIPTION
 - added condition to check optind <= 0
 - improved handling of options --
 - for return getopt() to initial state set optind = 0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
