### PR TITLE
Add error handling to fprintf and reduce memory usage of dprintf

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -90,7 +90,7 @@ extern FILE *stderr, *stdin, *stdout;
 #define stdout stdout
 
 /* Closes the stream. All buffers are flushed. */
-extern int fclose(FILE *file);
+extern int fclose(FILE *stream);
 
 
 /* Clears the end-of-file and error indicators for the given stream. */
@@ -333,8 +333,8 @@ extern void _file_init(void);
 
 
 /* stdio locking functions */
-extern void flockfile(FILE *file);
-extern void funlockfile(FILE *file);
+extern void flockfile(FILE *stream);
+extern void funlockfile(FILE *stream);
 
 
 #endif

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -198,7 +198,7 @@ extern char *tmpnam(char *str);
 extern int fprintf(FILE *stream, const char *format, ...);
 
 
-/* Sends formatted outout to a file descriptor. */
+/* Sends formatted output to a file descriptor. */
 extern int dprintf(int fd, const char *format, ...);
 
 
@@ -216,6 +216,10 @@ extern int snprintf(char *str, size_t n, const char *format, ...);
 
 /* Sends formatted output to a stream using an argument list. */
 extern int vfprintf(FILE *stream, const char *format, va_list arg);
+
+
+/* Sends formatted output to a file descriptor using an argument list. */
+extern int vdprintf(int fd, const char *format, va_list arg);
 
 
 /* Sends formatted output to stdout using an argument list. */


### PR DESCRIPTION
This change:
- removes temporarily allocated memory by `dprintf()`,
- adds `vdprintf()`,
- adds error handling to `fprintf()`, `vfprintf()` which operates on the file stream and to `vdprintf()`, `dprintf()` which operates on the file descriptor.

JIRA: RTOS-277

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32=generic`, `imxrt1176-nil`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
