### PR TITLE
sys/mount: add checking mtMount result in mount()

### DIFF
--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -30,9 +30,15 @@ enum { mtMount = 0xf50, mtUmount, mtSync, mtStat };
 
 typedef struct {
 	long id;
-	unsigned mode;
+	unsigned long mode;
 	char fstype[16];
-} mount_msg_t;
+} __attribute__((packed)) mount_i_msg_t;
+
+
+typedef struct {
+	int err;
+	oid_t root;
+} __attribute__((packed)) mount_o_msg_t;
 
 
 extern int fileAdd(unsigned int *h, oid_t *oid, unsigned mode);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Renamed `mount_msg_t` to `mount_i_msg_t`.
Added `mount_o_msg_t` as `mtMount` message result.
Added checking `mtMount` result in `mount()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-290](https://jira.phoenix-rtos.com/browse/RTOS-290)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/557
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
