### PR TITLE
sys/mount: fix mount() signature

### DIFF
--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -35,7 +35,7 @@
 #define MS_SILENT      (1 << 15)
 
 
-extern int mount(const char *source, const char *target, const char *fstype, unsigned long mode, char *data);
+extern int mount(const char *source, const char *target, const char *fstype, unsigned long mode, const char *data);
 
 
 extern int umount(const char *path);

--- a/sys/mount.c
+++ b/sys/mount.c
@@ -22,7 +22,7 @@
 #include <sys/msg.h>
 
 
-int mount(const char *source, const char *target, const char *fstype, long mode, char *data)
+int mount(const char *source, const char *target, const char *fstype, unsigned long mode, const char *data)
 {
 	struct stat buf;
 	oid_t toid, soid, doid, *doidp;
@@ -70,7 +70,7 @@ int mount(const char *source, const char *target, const char *fstype, long mode,
 	mnt->fstype[sizeof(mnt->fstype) - 1] = '\0';
 
 	msg.i.size = data != NULL ? strlen(data) : 0;
-	msg.i.data = data;
+	msg.i.data = (char *)data; /* FIXME: dropping const because of broken msg_t declaration */
 
 	if (msgSend(soid.port, &msg) < 0)
 		return SET_ERRNO(-EIO);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixed `mount()` `mode` and `data` parameter types.
Please note that `data` parameter type is `const void *` on Linux. We're using `const char *` type in order to obtain `data` size
with `strlen()` in `mount()` implementation (we assume that `data` is a `NULL` terminated string, no use case for now).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-291](https://jira.phoenix-rtos.com/browse/RTOS-291)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
