### PR TITLE
Maxez/feature umount

### DIFF
--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -30,9 +30,15 @@ enum { mtMount = 0xf50, mtUmount, mtSync, mtStat };
 
 typedef struct {
 	long id;
-	unsigned mode;
+	unsigned long mode;
 	char fstype[16];
-} mount_msg_t;
+} mount_i_msg_t;
+
+
+typedef struct {
+	int err;
+	oid_t oid;
+} mount_o_msg_t;
 
 
 extern int fileAdd(unsigned int *h, oid_t *oid, unsigned mode);

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -25,11 +25,12 @@ enum { otDir = 0, otFile, otDev, otSymlink, otUnknown };
 enum { atMode = 0, atUid, atGid, atSize, atBlocks, atIOBlock, atType, atPort, atPollStatus, atEventMask, atCTime, atMTime, atATime, atLinks, atDev };
 
 
-enum { mtMount = 0xf50, mtUmount, mtSync, mtStat };
+enum { mtMount = 0xf50, mtUmount, mtSync, mtStat, mtMountPoint };
 
 
 typedef struct {
-	long id;
+	oid_t dev;
+	oid_t mnt;
 	unsigned long mode;
 	char fstype[16];
 } mount_i_msg_t;

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -35,9 +35,10 @@
 #define MS_SILENT      (1 << 15)
 
 
-extern int mount(const char *source, const char *target, const char *fstype, unsigned long mode, char *data);
+extern int mount(const char *source, const char *target, const char *fstype, unsigned long mode, const char *data);
 
 
 extern int umount(const char *path);
+
 
 #endif

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -38,7 +38,7 @@
 extern int mount(const char *source, const char *target, const char *fstype, unsigned long mode, const char *data);
 
 
-extern int umount(const char *path);
+extern int umount(const char *target);
 
 
 #endif

--- a/posix/stubs.c
+++ b/posix/stubs.c
@@ -162,10 +162,6 @@ int flock(int fd, int operation)
 	return 0;
 }
 
-int umount(const char *path)
-{
-	return 0;
-}
 
 long ulimit(int __cmd, ...)
 {

--- a/sys/mount.c
+++ b/sys/mount.c
@@ -22,7 +22,7 @@
 #include <sys/msg.h>
 
 
-int mount(const char *source, const char *target, const char *fstype, long mode, char *data)
+int mount(const char *source, const char *target, const char *fstype, unsigned long mode, const char *data)
 {
 	struct stat buf;
 	oid_t toid, soid, doid;
@@ -71,7 +71,7 @@ int mount(const char *source, const char *target, const char *fstype, long mode,
 	imnt->fstype[sizeof(imnt->fstype) - 1] = '\0';
 
 	msg.i.size = data != NULL ? strlen(data) : 0;
-	msg.i.data = data;
+	msg.i.data = (char *)data; /* FIXME: dropping const because of broken msg_t declaration */
 
 	if (msgSend(soid.port, &msg) < 0)
 		return SET_ERRNO(-EIO);

--- a/sys/mount.c
+++ b/sys/mount.c
@@ -65,7 +65,8 @@ int mount(const char *source, const char *target, const char *fstype, unsigned l
 		return SET_ERRNO(-ENOTDIR);
 
 	msg.type = mtMount;
-	imnt->id = soid.id;
+	imnt->dev = soid;
+	imnt->mnt = toid;
 	imnt->mode = mode;
 	strncpy(imnt->fstype, fstype, sizeof(imnt->fstype));
 	imnt->fstype[sizeof(imnt->fstype) - 1] = '\0';

--- a/sys/mount.c
+++ b/sys/mount.c
@@ -25,12 +25,13 @@
 int mount(const char *source, const char *target, const char *fstype, long mode, char *data)
 {
 	struct stat buf;
-	oid_t toid, soid, doid, *doidp;
+	oid_t toid, soid, doid;
 	msg_t msg = {0};
 	char *source_abspath, *target_abspath;
 	int err;
 
-	mount_msg_t *mnt = (mount_msg_t *)msg.i.raw;
+	mount_i_msg_t *imnt = (mount_i_msg_t *)msg.i.raw;
+	mount_o_msg_t *omnt = (mount_o_msg_t *)msg.o.raw;
 
 	if ((target_abspath = resolve_path(target, NULL, 1, 0)) == NULL)
 		return -1; /* errno set by resolve_path */
@@ -64,10 +65,10 @@ int mount(const char *source, const char *target, const char *fstype, long mode,
 		return SET_ERRNO(-ENOTDIR);
 
 	msg.type = mtMount;
-	mnt->id = soid.id;
-	mnt->mode = mode;
-	strncpy(mnt->fstype, fstype, sizeof(mnt->fstype));
-	mnt->fstype[sizeof(mnt->fstype) - 1] = '\0';
+	imnt->id = soid.id;
+	imnt->mode = mode;
+	strncpy(imnt->fstype, fstype, sizeof(imnt->fstype));
+	imnt->fstype[sizeof(imnt->fstype) - 1] = '\0';
 
 	msg.i.size = data != NULL ? strlen(data) : 0;
 	msg.i.data = data;
@@ -75,9 +76,13 @@ int mount(const char *source, const char *target, const char *fstype, long mode,
 	if (msgSend(soid.port, &msg) < 0)
 		return SET_ERRNO(-EIO);
 
-	doidp = (oid_t *)msg.o.raw;
-	doid = *doidp;
+	/* Mount failed */
+	if (omnt->err < 0) {
+		return SET_ERRNO(omnt->err);
+	}
+	doid = omnt->oid;
 
+	/* Create mountpoint */
 	memset(&msg, 0, sizeof(msg));
 
 	msg.type = mtSetAttr;

--- a/sys/mount.c
+++ b/sys/mount.c
@@ -97,3 +97,115 @@ int mount(const char *source, const char *target, const char *fstype, unsigned l
 
 	return SET_ERRNO(msg.o.attr.err);
 }
+
+
+int umount(const char *target)
+{
+	msg_t msg = { 0 };
+	mount_o_msg_t *omnt = (mount_o_msg_t *)msg.o.raw;
+	int rootfs = 0;
+	oid_t oid, dev;
+	char *abspath;
+
+	abspath = resolve_path(target, NULL, 1, 0);
+	if (abspath == NULL) {
+		/* errno set by resolve_path() */
+		return -1;
+	}
+
+	if (lookup(abspath, &oid, &dev) < 0) {
+		free(abspath);
+		return SET_ERRNO(-ENOENT);
+	}
+
+	/* Check for attached device */
+	if (oid.port == dev.port) {
+		/* Check for rootfs */
+		if ((abspath[0] == '/') && (abspath[1] == '\0')) {
+			rootfs = 1;
+		}
+		/* Invalid target, neither device nor mountpoint */
+		else {
+			free(abspath);
+			return SET_ERRNO(-EINVAL);
+		}
+	}
+	free(abspath);
+
+	/* Check file type */
+	msg.type = mtGetAttr;
+	msg.i.attr.type = atMode;
+	msg.i.attr.oid = oid;
+
+	if (msgSend(oid.port, &msg) < 0) {
+		return SET_ERRNO(-EIO);
+	}
+
+	if (msg.o.attr.err < 0) {
+		return SET_ERRNO(msg.o.attr.err);
+	}
+
+	/* Got mountpoint */
+	if (S_ISDIR(msg.o.attr.val)) {
+		/* TODO: implement umount() by mountpoint, set ENOTSUP errno for now */
+		return SET_ERRNO(-ENOTSUP);
+	}
+	/* Got mounted device */
+	/* TODO: check device type (should be S_IFBLK?) */
+	else {
+		/* Get mountpoint */
+		msg.type = mtMountPoint;
+		msg.i.data = &dev;
+		msg.i.size = sizeof(dev);
+
+		if (msgSend(dev.port, &msg) < 0) {
+			return SET_ERRNO(-EIO);
+		}
+
+		if (omnt->err < 0) {
+			/* Check for rootfs */
+			if (omnt->err == -ENOENT) {
+				rootfs = 1;
+			}
+			/* No mountpoint */
+			else {
+				return SET_ERRNO(omnt->err);
+			}
+		}
+		else {
+			oid = omnt->oid;
+		}
+	}
+
+	/* Unmount filesystem */
+	msg.type = mtUmount;
+	msg.i.data = &dev;
+	msg.i.size = sizeof(dev);
+
+	if (msgSend(dev.port, &msg) < 0) {
+		return SET_ERRNO(-EIO);
+	}
+
+	if (msg.o.io.err < 0) {
+		return SET_ERRNO(msg.o.io.err);
+	}
+
+	/* Remove mountpoint */
+	if (rootfs == 0) {
+		msg.type = mtSetAttr;
+		msg.i.attr.type = atDev;
+		msg.i.attr.oid = oid;
+		msg.i.data = &oid;
+		msg.i.size = sizeof(oid);
+
+		if (msgSend(oid.port, &msg) < 0) {
+			return SET_ERRNO(-EIO);
+		}
+
+		return SET_ERRNO(msg.o.attr.err);
+	}
+	/* TODO: unregister root in kernel */
+	else {
+		return EOK;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Renamed `mount_msg_t` to `mount_i_msg_t`.
Added `mount_o_msg_t` as `mtMount` message result.
Added checking `mtMount` result in `mount()`.

Fixed `mount()` `mode` and `data` parameter types.
Please note that `data` parameter type is `const void *` on Linux. We're using `const char *` type in order to obtain `data` size
with `strlen()` in `mount()` implementation (we assume that `data` is a `NULL` terminated string, no use case for now).

Added `oid_t mnt` field to `mount_msg_t`. Changed mounted device `long id` field to `oid_t dev`.
Added new `mtMountPoint` message for retrieving mountpoint oid from device.

Added `umount()` implementation. The `target` parameter must be a mounted device. Unmounting by mountpoint `target` is not yet supported.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-290](https://jira.phoenix-rtos.com/browse/RTOS-290)
[JIRA: RTOS-291](https://jira.phoenix-rtos.com/browse/RTOS-291)
[JIRA: RTOS-293](https://jira.phoenix-rtos.com/browse/RTOS-293)
[JIRA: DTR-101](https://jira.phoenix-rtos.com/browse/DTR-101)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
