### PR TITLE
stdio: Add missing prototypes

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -249,6 +249,18 @@ extern int asprintf(char **strp, const char *fmt, ...);
 extern int vasprintf(char **strp, const char *fmt, va_list ap);
 
 
+/* Reads formatted input from a stream using an argument list. */
+extern int vfscanf(FILE *stream, const char *format, va_list ap);
+
+
+/* Reads formatted input from a string using an argument list. */
+extern int vsscanf(const char *str, const char *format, va_list ap);
+
+
+/* Reads formatted input from stdin using an argument list. */
+extern int vscanf(const char *format, va_list ap);
+
+
 /* Reads formatted input from a stream. */
 extern int fscanf(FILE *stream, const char *format, ...);
 
@@ -337,6 +349,11 @@ extern FILE *popen(const char *command, const char *type);
 extern int pclose(FILE *stream);
 
 
+/* Reads a string input delimited by a user-specified character. */
+extern ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream);
+
+
+/* Reads a string separated by a newline character. */
 extern ssize_t getline(char **lineptr, size_t *n, FILE *stream);
 
 


### PR DESCRIPTION
Adds mising prototypes of the following functions getdelim(), vfscanf(), vscanf(), vsscanf()

Fixes issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/583

JIRA: RTOS-323

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, ia32-generic, stm32l4a6-nucleo).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
