### PR TITLE
stdio/format: Fix printf %{g, s, c}. Add %{G, f, F, e, E, a, A}

### DIFF
--- a/stdio/Makefile
+++ b/stdio/Makefile
@@ -4,4 +4,4 @@
 # Copyright 2017, 2019, 2020 Phoenix Systems
 #
 
-OBJS += $(addprefix $(PREFIX_O)stdio/, printf.o sprintf.o asprintf.o fprintf.o format.o scanf.o file.o perror.o)
+OBJS += $(addprefix $(PREFIX_O)stdio/, printf.o sprintf.o asprintf.o fprintf.o format.o scanf.o file.o perror.o bignum.o)

--- a/stdio/bignum.c
+++ b/stdio/bignum.c
@@ -1,0 +1,240 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * bignum.c
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Andrzej Stalke
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "bignum.h"
+
+
+static void bignum_shiftrInternal(bignum_t *bn, const size_t shift)
+{
+	bignum_data_t carry = 0, temp;
+	const bignum_data_t mask = BIGNUM_DATA_MASK >> (BIGNUM_DATA_BITS - shift);
+	ssize_t i;
+	for (i = bn->len - 1; i >= 0; --i) {
+		temp = bn->data[i];
+		if (shift == BIGNUM_DATA_BITS) {
+			bn->data[i] = 0;
+		}
+		else {
+			bn->data[i] >>= shift;
+		}
+		bn->data[i] |= carry;
+		carry = (temp & mask) << (BIGNUM_DATA_BITS - shift);
+	}
+}
+
+
+static int bignum_resize(bignum_t *bn, const size_t newSize)
+{
+	bignum_data_t *ptr = realloc(bn->data, sizeof(*bn->data) * newSize);
+	if (ptr != NULL) {
+		bn->size = newSize;
+		bn->data = ptr;
+		return 0;
+	}
+	return -1;
+}
+
+
+static int bignum_shiftlInternal(bignum_t *bn, const size_t shift)
+{
+	bignum_data_t temp, carry = 0;
+	const bignum_data_t mask = ~((1LLU << (BIGNUM_DATA_BITS - shift)) - 1);
+	size_t i;
+	int ret = 0;
+	for (i = 0; i < bn->len; ++i) {
+		temp = bn->data[i];
+		/* Shift by BIGNUM_DATA_BITS is UB, so condition is necessary */
+		if (shift == BIGNUM_DATA_BITS) {
+			bn->data[i] = 0;
+		}
+		else {
+			bn->data[i] = bn->data[i] << shift;
+		}
+		bn->data[i] |= carry;
+		carry = (temp & mask) >> (BIGNUM_DATA_BITS - shift);
+	}
+	if (carry != 0) {
+		ret = bignum_push(bn, carry);
+	}
+	return ret;
+}
+
+
+static int bignum_cmpInternal(const bignum_t *first, const bignum_t *second)
+{
+	size_t i;
+	if (first->len < second->len) {
+		return -bignum_cmpInternal(second, first);
+	}
+
+	for (i = first->len - 1; i >= second->len; --i) {
+		if (first->data[i] != 0) {
+			return 1;
+		}
+	}
+
+	i = second->len;
+	do {
+		--i;
+		if (first->data[i] > second->data[i]) {
+			return 1;
+		}
+		else {
+			if (first->data[i] < second->data[i]) {
+				return -1;
+			}
+		}
+	} while (i != 0);
+	return 0;
+}
+
+
+int bignum_init(bignum_t *bn, size_t size, bignum_data_t val)
+{
+	bignum_t result = { .data = NULL, .len = 1, .size = size };
+	result.data = calloc(result.size, sizeof(*result.data));
+	if (result.data != NULL) {
+		result.data[0] = val;
+		*bn = result;
+		return 0;
+	}
+	else {
+		return -1;
+	}
+}
+
+void bignum_destroy(bignum_t *bn)
+{
+	if (bn != NULL) {
+		free(bn->data);
+		bn->data = NULL;
+		bn->len = 0;
+		bn->size = 0;
+	}
+}
+
+
+void bignum_zero(bignum_t *bn)
+{
+	size_t i;
+	for (i = 0; i < bn->size; ++i) {
+		bn->data[i] = 0;
+	}
+	bn->len = 1;
+}
+
+
+int bignum_shiftl(bignum_t *bn, size_t shift)
+{
+	int ret;
+	while (shift > BIGNUM_DATA_BITS) {
+		ret = bignum_shiftlInternal(bn, BIGNUM_DATA_BITS);
+		if (ret != 0) {
+			return ret;
+		}
+		shift -= BIGNUM_DATA_BITS;
+	}
+	return bignum_shiftlInternal(bn, shift);
+}
+
+
+void bignum_shiftr(bignum_t *bn, size_t shift)
+{
+	while (shift > BIGNUM_DATA_BITS) {
+		bignum_shiftrInternal(bn, BIGNUM_DATA_BITS);
+		shift -= BIGNUM_DATA_BITS;
+	}
+	if (shift != 0) {
+		bignum_shiftrInternal(bn, shift);
+	}
+}
+
+
+/*
+ *  1 : first > second
+ *  0 : first == second
+ * -1 : first < second
+ */
+int bignum_cmp(const bignum_t *first, uint32_t val)
+{
+	const bignum_t second = { .data = &val, .len = 1, .size = 1 };
+	return bignum_cmpInternal(first, &second);
+}
+
+
+int bignum_copy(bignum_t *target, const bignum_t *source)
+{
+	size_t i;
+	int res = 0;
+	if (target->size < source->size) {
+		res = bignum_resize(target, source->size);
+		if (res != 0) {
+			return res;
+		}
+	}
+	for (i = 0; i < source->size; ++i) {
+		target->data[i] = source->data[i];
+	}
+	target->len = source->len;
+	return res;
+}
+
+int bignum_mul(bignum_t *first, uint32_t val)
+{
+	size_t i;
+	bignum_ddata_t temp;
+	bignum_data_t carry = 0;
+	int res = 0;
+
+	for (i = 0; i < first->len; ++i) {
+		temp = first->data[i];
+		temp *= val;
+		temp += carry;
+		first->data[i] = temp & BIGNUM_DATA_MASK;
+		carry = temp >> BIGNUM_DATA_BITS;
+	}
+	if (carry > 0) {
+		res = bignum_push(first, carry);
+	}
+	return res;
+}
+
+
+void bignum_div(bignum_t *dividend, uint32_t *remainder, uint32_t divisor)
+{
+	ssize_t i;
+	bignum_ddata_t temp = 0;
+	for (i = dividend->len - 1; i >= 0; --i) {
+		temp <<= BIGNUM_DATA_BITS;
+		temp |= dividend->data[i];
+		dividend->data[i] = temp / divisor;
+		temp %= divisor;
+	}
+	*remainder = temp;
+}
+
+
+int bignum_push(bignum_t *bn, bignum_data_t val)
+{
+	int res;
+	if (bn->len >= bn->size) {
+		res = bignum_resize(bn, bn->size << 1);
+		if (res != 0) {
+			return res;
+		}
+	}
+	bn->data[bn->len++] = val;
+	return 0;
+}

--- a/stdio/bignum.h
+++ b/stdio/bignum.h
@@ -1,0 +1,63 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * bignum.h
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Andrzej Stalke
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+#ifndef _LIBPHOENIX_STDIO_BIGNUM_H
+#define _LIBPHOENIX_STDIO_BIGNUM_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define BIGNUM_DATA_BITS     (8 * sizeof(bignum_data_t))
+#define BIGNUM_DATA_MASK     ((bignum_data_t)(((bignum_ddata_t)1 << BIGNUM_DATA_BITS) - 1))
+#define DOUBLE_EXP_SHIFT     52
+#define DOUBLE_MANTISSA_MASK ((1LLU << DOUBLE_EXP_SHIFT) - 1)
+
+typedef uint32_t bignum_data_t;
+typedef uint64_t bignum_ddata_t;
+
+typedef struct bignum {
+	bignum_data_t *data;
+	size_t len, size;
+} bignum_t;
+
+extern int bignum_init(bignum_t *bn, size_t size, bignum_data_t val);
+
+
+extern void bignum_destroy(bignum_t *bn);
+
+
+extern void bignum_zero(bignum_t *bn);
+
+
+extern int bignum_shiftl(bignum_t *bn, size_t shift);
+
+
+extern void bignum_shiftr(bignum_t *bn, size_t shift);
+
+
+extern int bignum_cmp(const bignum_t *first, uint32_t val);
+
+
+extern int bignum_copy(bignum_t *target, const bignum_t *source);
+
+
+extern int bignum_mul(bignum_t *first, uint32_t val);
+
+
+extern void bignum_div(bignum_t *dividend, uint32_t *remainder, uint32_t divisor);
+
+
+extern int bignum_push(bignum_t *bn, bignum_data_t val);
+
+#endif /*_LIBPHOENIX_STDIO_BIGNUM_H*/

--- a/stdio/format.c
+++ b/stdio/format.c
@@ -5,8 +5,8 @@
  *
  * format.c
  *
- * Copyright 2017 Phoenix Systems
- * Author: Adrian Kepka
+ * Copyright 2017, 2023 Phoenix Systems
+ * Author: Adrian Kepka, Andrzej Stalke
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -15,26 +15,28 @@
 
 #include <sys/minmax.h>
 #include "format.h"
+#include "bignum.h"
 #include <sys/minmax.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
-
-#define FLAG_SIGNED        0x1
-#define FLAG_64BIT         0x2
-#define FLAG_FLOAT         0x4
-#define FLAG_SPACE         0x10
-#define FLAG_ZERO          0x20
-#define FLAG_PLUS          0x40
-#define FLAG_HEX           0x80
-#define FLAG_OCT           0x100
-#define FLAG_LARGE_DIGITS  0x200
-#define FLAG_ALTERNATE     0x400
-#define FLAG_NULLMARK      0x800
-#define FLAG_MINUS         0x1000
+#define FLAG_SIGNED             0x1
+#define FLAG_64BIT              0x2
+#define FLAG_NO_TRAILING_ZEROS  0x4
+#define FLAG_SPACE              0x10
+#define FLAG_ZERO               0x20
+#define FLAG_PLUS               0x40
+#define FLAG_HEX                0x80
+#define FLAG_OCT                0x100
+#define FLAG_LARGE_DIGITS       0x200
+#define FLAG_ALTERNATE          0x400
+#define FLAG_NULLMARK           0x800
+#define FLAG_MINUS              0x1000
 #define FLAG_FIELD_WIDTH_STAR 	0x2000
-#define FLAG_DOUBLE		   0x4000
+
+#define DOUBLE_EXP_INVALID             1024
+#define HEXDOUBLE_SUFFICIENT_PRECISION 13
 
 
 #define GET_UNSIGNED(number, flags, args) do {		\
@@ -52,26 +54,65 @@
 			(number) = va_arg((args), int32_t);	\
 	} while (0)
 
-
-union float_u32
-{
-	float f;
-	uint32_t u;
-};
-
-union double_u64
-{
+union double_u64 {
 	double d;
 	uint64_t u;
 };
 
-static inline double format_doubleFromU64(uint64_t ui)
-{
-	union double_u64 u;
+struct buffer {
+	char *data;
+	size_t len, size;
+};
 
-	u.u = ui;
-	return u.d;
+struct bigdouble {
+	/* Stored number */
+	bignum_t num;
+	/* Helper values */
+	bignum_t helper1;
+	uint64_t firstIntegerBit;
+};
+
+static const char smallDigits[] = "0123456789abcdef";
+static const char largeDigits[] = "0123456789ABCDEF";
+
+
+static inline int format_bufferInit(struct buffer *buff, size_t size)
+{
+	char *data = malloc(size);
+	if (data != NULL) {
+		*buff = (struct buffer) { .data = data, .len = 0, .size = size };
+		return 0;
+	}
+	else {
+		return -1;
+	}
 }
+
+
+static inline int format_bufferAddChar(struct buffer *buff, char c)
+{
+	char *data;
+	if (buff->len >= buff->size) {
+		data = realloc(buff->data, 2 * buff->size);
+		if (data == NULL) {
+			return -1;
+		}
+		buff->data = data;
+		buff->size = 2 * buff->size;
+	}
+	buff->data[buff->len++] = c;
+	return 0;
+}
+
+
+static inline void format_bufferDestroy(struct buffer *buff)
+{
+	free(buff->data);
+	buff->data = NULL;
+	buff->size = 0;
+	buff->len = 0;
+}
+
 
 static inline uint64_t format_u64FromDouble(double d)
 {
@@ -81,311 +122,661 @@ static inline uint64_t format_u64FromDouble(double d)
 	return u.u;
 }
 
-static inline float format_floatFromU32(uint32_t ui)
-{
-	union float_u32 u;
 
-	u.u = ui;
-	return u.f;
+static inline int32_t format_doubleGetExponent(uint64_t num64)
+{
+	return ((int32_t)((num64 >> DOUBLE_EXP_SHIFT) & 0x7ff) - 1023);
 }
 
 
-static inline uint32_t format_u32FromFloat(float f)
+static int format_bigdoubleInit(struct bigdouble *bd, const size_t size)
 {
-	union float_u32 u;
-
-	u.f = f;
-	return u.u;
+	int res = bignum_init(&bd->num, size, 0);
+	if (res != 0) {
+		return res;
+	}
+	res = bignum_init(&bd->helper1, size, 0);
+	if (res != 0) {
+		bignum_destroy(&bd->num);
+		return res;
+	}
+	bd->firstIntegerBit = 0;
+	return 0;
 }
 
 
-static inline float format_modff(float x, float *integral_out)
+static void format_bigdoubleDestroy(struct bigdouble *bd)
 {
-	int h;
-	float high_int, low, low_int, frac;
+	bignum_destroy(&bd->num);
+	bignum_destroy(&bd->helper1);
+}
 
-	if (x > 1048576.0f) {
 
-		h = (int)(x / 1048576.0f);
-		high_int = (float)h * 1048576.0f;
-		low = x - high_int;
+static int format_bigdoubleIntegerPart(const struct bigdouble *bd, bignum_t *result)
+{
+	int res = bignum_copy(result, &bd->num);
+	if (res == 0) {
+		bignum_shiftr(result, bd->firstIntegerBit);
+	}
+	return res;
+}
 
-		low_int = (float)(int)low;
-		frac = low - low_int;
-		*integral_out = high_int * 1048576.0f + low_int;
-		return frac;
+
+static void format_bigdoubleCutIntegerPart(struct bigdouble *result)
+{
+	const size_t firstIntegerIndex = result->firstIntegerBit / BIGNUM_DATA_BITS;
+	const size_t fracMask = (1LLU << (result->firstIntegerBit % BIGNUM_DATA_BITS)) - 1;
+	if (firstIntegerIndex < result->num.len) {
+		result->num.data[firstIntegerIndex] &= fracMask;
+		result->num.len = firstIntegerIndex + 1;
+	}
+}
+
+
+static int format_bigdoubleLoad(struct bigdouble *result, double val)
+{
+	uint64_t num64 = format_u64FromDouble(val);
+	int32_t exp = format_doubleGetExponent(num64);
+	const int isSubnormalOrZero = exp == -1023;
+	uint64_t mantissa = num64 & DOUBLE_MANTISSA_MASK;
+	int res = format_bigdoubleInit(result, 1024);
+
+	if (res != 0) {
+		return res;
+	}
+	bignum_zero(&result->num);
+	if ((isSubnormalOrZero != 0) && (mantissa == 0)) {
+		/* val == 0 */
+		result->firstIntegerBit = 0;
+		return 0;
+	}
+	/* val != 0 */
+	mantissa |= (isSubnormalOrZero != 0 ? 0LLU : 1LLU) << DOUBLE_EXP_SHIFT;
+	result->num.data[0] = mantissa & BIGNUM_DATA_MASK;
+	mantissa >>= BIGNUM_DATA_BITS;
+	res = bignum_push(&result->num, (bignum_data_t)mantissa);
+	if (res != 0) {
+		format_bigdoubleDestroy(result);
+		return res;
+	}
+	if (isSubnormalOrZero != 0) {
+		exp = -1022;
+	}
+	/* Check if there is no fractional part */
+	if (DOUBLE_EXP_SHIFT < exp) {
+		result->firstIntegerBit = 0;
+		res = bignum_shiftl(&result->num, exp - DOUBLE_EXP_SHIFT);
+	}
+	else {
+		result->firstIntegerBit = DOUBLE_EXP_SHIFT - exp;
+	}
+	return res;
+}
+
+
+static void format_printBuffer(void *ctx, feedfunc feed, uint32_t flags, int minFieldWidth, const char *start, const char *end, char sign)
+{
+	const int digits_cnt = start > end ? start - end : end - start;
+	int pad_len = minFieldWidth - digits_cnt - (sign ? 1 : 0);
+	/* If FLAG_ZERO and FLAG_MINUS both appear, then FLAG_ZERO is ignored */
+	if ((flags & FLAG_MINUS) != 0) {
+		flags &= ~FLAG_ZERO;
 	}
 
-	low_int = (float)(int)x;
-	frac = x - low_int;
-	*integral_out = low_int;
-
-	return frac;
-}
-
-
-static inline uint32_t format_fracToU32(float frac, int float_frac_len, float *overflow)
-{
-	const uint32_t s_powers10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, };
-	const uint32_t mult = s_powers10[float_frac_len];
-
-	frac *= (float)mult;
-
-	/* Ensure proper rounding */
-	frac += 0.5f;
-	uint32_t ret = (uint32_t)(int32_t)frac;
-
-	if (ret >= mult) {
-		*overflow += 1;
-		ret -= mult;
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) == 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, ' ');
+		}
 	}
-	return ret;
+
+	if (sign != 0) {
+		feed(ctx, sign);
+	}
+
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) != 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, '0');
+		}
+	}
+
+	/* copy */
+	if (start > end) {
+		while ((--start) >= end) {
+			feed(ctx, *start);
+		}
+	}
+	else {
+		while (start < end) {
+			feed(ctx, *start++);
+		}
+	}
+
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) != 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, ' ');
+		}
+	}
 }
 
 
-static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_t flags, int min_number_len, int float_frac_len)
+static void format_bufferReverse(char *buff, size_t start, size_t end)
 {
-	const char *digits = (flags & FLAG_LARGE_DIGITS) ? "0123456789ABCDEF" : "0123456789abcdef",
-			*prefix = (flags & FLAG_LARGE_DIGITS) ? "X0" : "x0";
+	char tmp;
+	end -= 1;
+	for (; start < end; ++start, --end) {
+		tmp = buff[start];
+		buff[start] = buff[end];
+		buff[end] = tmp;
+	}
+}
+
+
+static void format_sprintfDecimalForm(struct buffer *buff, struct bigdouble *bd, uint32_t flags, int precision, unsigned int *startOffset)
+{
+	char *carrier;
+
+	unsigned int removeTrailingZeros = flags & FLAG_NO_TRAILING_ZEROS && !(flags & FLAG_ALTERNATE);
+	unsigned int carry = 0;
+	uint32_t remainder;
+	int i, length;
+
+	/* Reserve space for potential additional digit, due to carry. For example: 99.996 -> 100.00 */
+	if (format_bufferAddChar(buff, 0) != 0) {
+		return;
+	}
+	*startOffset = 1;
+
+	if (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0) {
+		return;
+	}
+	format_bigdoubleCutIntegerPart(bd);
+
+	/* Integer part */
+	length = 0;
+	do {
+		bignum_div(&bd->helper1, &remainder, 10);
+		if (format_bufferAddChar(buff, smallDigits[remainder]) != 0) {
+			return;
+		}
+		length += 1;
+	} while (bignum_cmp(&bd->helper1, 0) != 0);
+	format_bufferReverse(buff->data, *startOffset, *startOffset + length);
+
+	/* Frac part */
+	if ((precision > 0) || ((flags & FLAG_ALTERNATE) != 0)) {
+		if (format_bufferAddChar(buff, '.')) {
+			return;
+		}
+	}
+	for (i = 0; i < precision; ++i) {
+		if (bignum_mul(&bd->num, 10) != 0) {
+			return;
+		}
+		if (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0) {
+			return;
+		}
+		format_bigdoubleCutIntegerPart(bd);
+		if (format_bufferAddChar(buff, smallDigits[bd->helper1.data[0] % 10]) != 0) {
+			return;
+		}
+	}
+	/* Rounding */
+	if ((bignum_mul(&bd->num, 10) != 0) || (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0)) {
+		return;
+	}
+
+	format_bigdoubleCutIntegerPart(bd);
+	if (bd->helper1.data[0] % 10 >= 5) {
+		carry = 1;
+	}
+
+	carrier = buff->data + buff->len - 1;
+	while (carry != 0) {
+		if (*carrier == 0) {
+			*carrier = '1';
+			*startOffset = 0;
+			carry = 0;
+		}
+		else if (*carrier == '9') {
+			*(carrier--) = '0';
+		}
+		else if (('0' <= *carrier) && (*carrier <= '8')) {
+			*carrier = *carrier + 1;
+			carry = 0;
+		}
+		else {
+			carrier--;
+		}
+	}
+	if (((precision > 0) || ((flags & FLAG_ALTERNATE) != 0)) && (removeTrailingZeros != 0)) {
+		--buff->len;
+		while (buff->data[buff->len] == '0')
+			--buff->len;
+		if (buff->data[buff->len] == '.') {
+			--buff->len;
+		}
+		++buff->len;
+	}
+}
+
+
+static void format_sprintfHexadecimalForm(struct buffer *buff, double d, uint32_t flags, const int precision, unsigned int *startOffset)
+{
+	const char *const digits = (flags & FLAG_LARGE_DIGITS) != 0 ? largeDigits : smallDigits;
+	uint32_t temp, carry = 0;
+	uint64_t num64 = format_u64FromDouble(d);
+	size_t currSize;
+	int32_t exp = format_doubleGetExponent(num64);
+	int i;
+
+	if ((format_bufferAddChar(buff, 0) != 0) || (format_bufferAddChar(buff, 0) != 0)) {
+		return;
+	}
+	if ((format_bufferAddChar(buff, 0) != 0) || (format_bufferAddChar(buff, 0) != 0)) {
+		return;
+	}
+	if (format_bufferAddChar(buff, 0) != 0) {
+		return;
+	}
+	*startOffset = 5;
+
+	for (i = 0; i < precision - HEXDOUBLE_SUFFICIENT_PRECISION; ++i) {
+		if (format_bufferAddChar(buff, 0) != 0) {
+			return;
+		}
+	}
+	for (i = 0; i < HEXDOUBLE_SUFFICIENT_PRECISION; ++i) {
+		if (format_bufferAddChar(buff, num64 % 16) != 0) {
+			return;
+		}
+		num64 /= 16;
+	}
+	format_bufferReverse(buff->data, *startOffset, buff->len);
+
+	*startOffset -= 1;
+	buff->data[*startOffset] = exp == -1023 ? 0 : 1;
+
+	if (precision < HEXDOUBLE_SUFFICIENT_PRECISION) {
+		i = *startOffset + precision;
+		temp = buff->data[i + 1];
+		if (temp >= 8) {
+			carry = 1;
+		}
+		while (carry != 0) {
+			if (buff->data[i] != 15) {
+				buff->data[i] += 1;
+				carry = 0;
+			}
+			else {
+				buff->data[i] = 0;
+			}
+			i -= 1;
+		}
+		if (i < *startOffset - 1) {
+			*startOffset = *startOffset - 1;
+		}
+	}
+	for (i = *startOffset; i <= *startOffset + precision; ++i) {
+		temp = buff->data[i];
+		buff->data[i] = digits[temp];
+	}
+
+	buff->len = *startOffset + 1 + precision;
+
+	if (!((precision == 0) && ((flags & FLAG_ALTERNATE) == 0))) {
+		*startOffset -= 1;
+		buff->data[*startOffset] = buff->data[*startOffset + 1];
+		buff->data[*startOffset + 1] = '.';
+	}
+	*startOffset -= 1;
+	buff->data[*startOffset] = (flags & FLAG_LARGE_DIGITS) != 0 ? 'X' : 'x';
+	*startOffset -= 1;
+	buff->data[*startOffset] = '0';
+
+	if (format_bufferAddChar(buff, ((flags & FLAG_LARGE_DIGITS) != 0) ? 'P' : 'p') != 0) {
+		return;
+	}
+	if (exp < 0) {
+		if (exp == -1023) {
+			exp = -1022;
+		}
+		exp = -exp;
+		if (format_bufferAddChar(buff, '-') != 0) {
+			return;
+		}
+	}
+	else {
+		if (format_bufferAddChar(buff, '+') != 0) {
+			return;
+		}
+	}
+	if (exp > 0) {
+		currSize = buff->len;
+		for (; exp > 0; exp /= 10) {
+			if (format_bufferAddChar(buff, digits[exp % 10]) != 0) {
+				return;
+			}
+		}
+		format_bufferReverse(buff->data, currSize, buff->len);
+	}
+	else {
+		if (format_bufferAddChar(buff, digits[0]) != 0) {
+			return;
+		}
+	}
+}
+
+
+static int format_sprintfScientificForm(struct buffer *buff, struct bigdouble *bd, uint32_t flags, const int precision, unsigned int *startOffset)
+{
+	char *carrier;
+	unsigned int removeTrailingZeros = flags & FLAG_NO_TRAILING_ZEROS && !(flags & FLAG_ALTERNATE);
+	unsigned int expIsPositive, carry = 0;
+	uint32_t remainder;
+	uint32_t temp;
+	int i, exp = 0, resexp = DOUBLE_EXP_INVALID;
+
+	/* Reserve space for potential additional digit (carry) and for a dot. */
+	if ((format_bufferAddChar(buff, 0) != 0) || (format_bufferAddChar(buff, 0) != 0)) {
+		return resexp;
+	}
+	*startOffset = 2;
+
+	if (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0) {
+		return resexp;
+	}
+	format_bigdoubleCutIntegerPart(bd);
+
+	/* Integer part */
+	if (bignum_cmp(&bd->helper1, 0) != 0) {
+		expIsPositive = 1;
+		do {
+			bignum_div(&bd->helper1, &remainder, 10);
+			if (format_bufferAddChar(buff, smallDigits[remainder]) != 0)
+				return resexp;
+			exp += 1;
+		} while (bignum_cmp(&bd->helper1, 0) != 0);
+		format_bufferReverse(buff->data, *startOffset, exp + *startOffset);
+		exp--;
+	}
+	else {
+		expIsPositive = 0;
+		do {
+			if ((bignum_mul(&bd->num, 10) != 0) || (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0)) {
+				return resexp;
+			}
+			format_bigdoubleCutIntegerPart(bd);
+			temp = bd->helper1.data[0] % 10;
+			--exp;
+		} while (temp == 0);
+		if (format_bufferAddChar(buff, smallDigits[temp]) != 0) {
+			return resexp;
+		}
+	}
+
+	for (i = 0; i <= precision; ++i) {
+		if ((bignum_mul(&bd->num, 10) != 0) || (format_bigdoubleIntegerPart(bd, &bd->helper1) != 0)) {
+			return resexp;
+		}
+		format_bigdoubleCutIntegerPart(bd);
+		if (format_bufferAddChar(buff, smallDigits[bd->helper1.data[0] % 10]) != 0) {
+			return resexp;
+		}
+	}
+
+	/* Remove garbage digits */
+	buff->len = *startOffset + precision + 2;
+
+	/* Rounding */
+	if (buff->data[*startOffset + precision + 1] - '0' >= 5) {
+		carry = 1;
+	}
+	buff->len -= 1;
+	carrier = buff->data + buff->len - 1;
+	while (carry != 0) {
+		if (*carrier == 0) {
+			*carrier = '1';
+			*startOffset -= 1;
+			carry = 0;
+			exp += 1;
+			buff->len -= 1;
+			if (exp == 0) {
+				expIsPositive = 1;
+			}
+		}
+		else if (*carrier == '9') {
+			*(carrier--) = '0';
+		}
+		else if (('0' <= *carrier) && (*carrier <= '8')) {
+			*carrier = *carrier + 1;
+			carry = 0;
+		}
+		else {
+			carrier--;
+		}
+	}
+
+	if ((precision > 0) || ((flags & FLAG_ALTERNATE) != 0)) {
+		/* Insert a dot */
+		*startOffset -= 1;
+		buff->data[*startOffset] = buff->data[*startOffset + 1];
+		buff->data[*startOffset + 1] = '.';
+
+		if (removeTrailingZeros != 0) {
+			--buff->len;
+			while (buff->data[buff->len] == '0') {
+				--buff->len;
+			}
+			if (buff->data[buff->len] == '.') {
+				--buff->len;
+			}
+			++buff->len;
+		}
+	}
+	if (format_bufferAddChar(buff, flags & FLAG_LARGE_DIGITS ? 'E' : 'e') != 0) {
+		return resexp;
+	}
+	if (format_bufferAddChar(buff, expIsPositive ? '+' : '-') != 0) {
+		return resexp;
+	}
+
+	resexp = exp;
+	if (expIsPositive == 0) {
+		exp = -exp;
+	}
+	i = buff->len;
+	if (format_bufferAddChar(buff, smallDigits[exp % 10]) != 0) {
+		return DOUBLE_EXP_INVALID;
+	}
+	exp /= 10;
+	if (exp == 0) {
+		if (format_bufferAddChar(buff, smallDigits[0]) != 0) {
+			return DOUBLE_EXP_INVALID;
+		}
+	}
+	else {
+		while (exp != 0) {
+			if (format_bufferAddChar(buff, smallDigits[exp % 10]) != 0) {
+				return DOUBLE_EXP_INVALID;
+			}
+			exp /= 10;
+		}
+	}
+	format_bufferReverse(buff->data, i, buff->len);
+	return resexp;
+}
+
+
+static void format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t flags, int minFieldWidth, int precision, char format)
+{
+	struct buffer buff;
+	char sign = 0;
+	const char *chosen, *infinity = (flags & FLAG_LARGE_DIGITS) ? "INF" : "inf",
+						*notNumber = (flags & FLAG_LARGE_DIGITS) ? "NAN" : "nan";
+	uint64_t num64 = format_u64FromDouble(d);
+	unsigned int startOffset = 0;
+	int i, prec, exp;
+	struct bigdouble bd, bd_backup;
+
+	if (format != 'a') {
+		precision = precision >= 0 ? precision : 6;
+	}
+	else {
+		precision = precision >= 0 ? precision : HEXDOUBLE_SUFFICIENT_PRECISION;
+	}
+
+	/* check sign */
+	if (((num64 >> 63) & 1) != 0) {
+		sign = '-';
+		d = -d;
+	}
+	else if ((flags & FLAG_PLUS) != 0) {
+		sign = '+';
+	}
+	else if ((flags & FLAG_SPACE) != 0) { /* If FLAG_PLUS and FLAG_SPACE both appear, then ignore SPACE */
+		sign = ' ';
+	}
+	else {
+		sign = '\0';
+	}
+	num64 = format_u64FromDouble(d);
+
+	if (format_bufferInit(&buff, 2 * precision + 6) != 0) {
+		return;
+	}
+
+	/* check special cases */
+	if (((num64 >> DOUBLE_EXP_SHIFT) & 0x7ff) == 0x7ff) {
+		/* for NaN and infinity, flags '#' and '0' have no effect */
+		flags &= ~(FLAG_ZERO | FLAG_ALTERNATE);
+		if ((num64 & 0xfffffffffffff) == 0) {
+			chosen = infinity;
+		}
+		else {
+			chosen = notNumber;
+		}
+		format_printBuffer(ctx, feed, flags, minFieldWidth, chosen, chosen + strlen(chosen), sign);
+		format_bufferDestroy(&buff);
+		return;
+	}
+
+	/* check zero */
+	if ((num64 & 0x7fffffffffffffff) == 0) {
+		if (format_bufferAddChar(&buff, '0') != 0) {
+			format_bufferDestroy(&buff);
+			return;
+		}
+		if (format == 'a') {
+			if ((format_bufferAddChar(&buff, (flags & FLAG_LARGE_DIGITS) ? 'X' : 'x') != 0) ||
+				(format_bufferAddChar(&buff, '0') != 0)) {
+				format_bufferDestroy(&buff);
+				return;
+			}
+		}
+		if (((flags & FLAG_ALTERNATE) != 0) || ((format != 'g') && (precision > 0))) {
+			if (format_bufferAddChar(&buff, '.') != 0) {
+				format_bufferDestroy(&buff);
+				return;
+			}
+			if (format == 'g') {
+				precision = precision ? precision - 1 : 0;
+			}
+			for (i = 0; i < precision; i++) {
+				if (format_bufferAddChar(&buff, '0') != 0) {
+					format_bufferDestroy(&buff);
+					return;
+				}
+			}
+		}
+		if (format == 'e') {
+			if ((format_bufferAddChar(&buff, (flags & FLAG_LARGE_DIGITS) ? 'E' : 'e') != 0) ||
+				(format_bufferAddChar(&buff, '+') != 0) || (format_bufferAddChar(&buff, '0') != 0) ||
+				(format_bufferAddChar(&buff, '0') != 0)) {
+				format_bufferDestroy(&buff);
+				return;
+			}
+		}
+		if (format == 'a') {
+			if ((format_bufferAddChar(&buff, (flags & FLAG_LARGE_DIGITS) ? 'P' : 'p') != 0) ||
+				(format_bufferAddChar(&buff, '+') != 0) || (format_bufferAddChar(&buff, '0') != 0)) {
+				format_bufferDestroy(&buff);
+				return;
+			}
+		}
+		format_printBuffer(ctx, feed, flags, minFieldWidth, buff.data, buff.data + buff.len, sign);
+		format_bufferDestroy(&buff);
+		return;
+	}
+
+	if (format_bigdoubleLoad(&bd, d) != 0) {
+		format_bufferDestroy(&buff);
+		return;
+	}
+
+	if (format == 'f') {
+		format_sprintfDecimalForm(&buff, &bd, flags, precision, &startOffset);
+	}
+	else if (format == 'e') {
+		format_sprintfScientificForm(&buff, &bd, flags, precision, &startOffset);
+	}
+	else if (format == 'g') {
+		if (format_bigdoubleInit(&bd_backup, 1024) != 0) {
+			format_bufferDestroy(&buff);
+			format_bigdoubleDestroy(&bd);
+			return;
+		}
+		if (bignum_copy(&bd_backup.num, &bd.num) != 0) {
+			format_bigdoubleDestroy(&bd_backup);
+			format_bufferDestroy(&buff);
+			format_bigdoubleDestroy(&bd);
+			return;
+		}
+		bd_backup.firstIntegerBit = bd.firstIntegerBit;
+
+		prec = precision ? precision : 1;
+		exp = format_sprintfScientificForm(&buff, &bd_backup, flags, prec - 1, &startOffset);
+		if ((prec > exp) && (exp >= -4)) {
+			buff.len = 0;
+			precision = prec - (exp + 1);
+			format_sprintfDecimalForm(&buff, &bd, flags, precision, &startOffset);
+		}
+		format_bigdoubleDestroy(&bd_backup);
+	}
+	else {
+		format_sprintfHexadecimalForm(&buff, d, flags, precision, &startOffset);
+	}
+	format_printBuffer(ctx, feed, flags, minFieldWidth, buff.data + startOffset, buff.data + buff.len, sign);
+	format_bufferDestroy(&buff);
+	format_bigdoubleDestroy(&bd);
+}
+
+
+static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_t flags, int minFieldWidth, int precision)
+{
+	const char *digits = (flags & FLAG_LARGE_DIGITS) ? largeDigits : smallDigits,
+			   *prefix = (flags & FLAG_LARGE_DIGITS) ? "X0" : "x0";
 	char tmp_buf[32];
 	char sign = 0;
 	char *tmp = tmp_buf;
 
-	if ((flags & FLAG_NULLMARK) && num64 == 0) {
+	if (((flags & FLAG_NULLMARK) != 0) && (num64 == 0)) {
 		const char *s = "(nil)";
+		const int s_len = strlen(s);
 		int i;
-		for(i = 0; i < strlen(s); i++)
+		for (i = 0; i < s_len; i++) {
 			feed(ctx, s[i]);
-	}
-
-	if (flags & FLAG_DOUBLE) {
-		double d = format_doubleFromU64(num64), exp_val;
-		/* exponent, exponent sign, trailing zeros, fraction lenght, integer lenght, temp */
-		int exp = 0, exps = 0, tz = 1, frac_len, int_len, temp, i;
-		/* fraction, temporary vars */
-		long long frac, temp1, temp2;
-
-		/* check sign */
-		if ((num64 >> 63) & 1) {
-			sign = '-';
-			d = -d;
-		}
-		num64 = format_u64FromDouble(d);
-
-		/* check zero */
-		if (!(num64 & 0x7fffffffffffffff)) {
-			if (sign)
-				feed(ctx, sign);
-			feed(ctx, '0');
-			sign = 0;
-			return;
-		}
-
-		/* check special cases */
-		if (((num64 >> 52) & 0x7ff) == 0x7ff) {
-			const char *s;
-			int i;
-			if (!(num64 & 0xfffffffffffff)) {
-				/* infinity */
-				s = "inf";
-				if (sign)
-					feed(ctx, sign);
-			}
-			else
-				s = "NaN";
-
-			for (i = 0; i < strlen(s); i++)
-				feed(ctx, s[i]);
-			sign = 0;
-			return;
-		}
-
-		frac_len = float_frac_len ? float_frac_len : 1;
-		int_len = 1;
-
-		if ((num64 >> 52) < 0x3ff) {
-
-			temp = ((int)((num64 >> 52) & 0x7ff) - 1023) / -4;
-
-			exp_val = 10;
-
-			for (i = 0; i < 9; i++) {
-				if ((temp >> i) & 1)
-					d *= exp_val;
-				exp_val *= exp_val;
-			}
-
-			temp1 = d;
-
-			num64 = format_u64FromDouble(d);
-			/* shift fraction left until it's >= 1*/
-			while ((num64 >> 52) < 0x3ff) {
-				exp++;
-				d *= 10;
-				num64 = format_u64FromDouble(d);
-			}
-			exp = temp + exp;
-		}
-
-		if (exp == 0) {
-			/* no shifting - number is larger than 1 */
-			exps = 1;
-
-			temp = ((int)((num64 >> 52) & 0x7ff) - 1023) / 4;
-
-			exp_val = 10;
-
-			for (i = 0; i < 9; i++) {
-				if ((temp >> i) & 1)
-					d /= exp_val;
-				exp_val *= exp_val;
-			}
-
-			num64 = format_u64FromDouble(d);
-			while((num64 >> 52) >= 0x3ff) {
-				exp++;
-				d /= 10;
-				num64 = format_u64FromDouble(d);
-			}
-
-			d *= 10;
-			exp--;
-			exp = temp + exp;
-			if (exp < float_frac_len) {
-				int_len += exp;
-				frac_len -= exp;
-				while (exp--)
-					d *= 10;
-				exp = 0;
-				frac = d;
-			}
-		}
-		temp = frac_len;
-
-		while (frac_len--)
-			d *= 10;
-
-		frac_len = temp - 1;
-		frac = d;
-		temp1 = frac / 10;
-
-		/* rounding */
-		frac += 5;
-		frac /= 10;
-		temp2 = frac;
-
-		while (frac_len--) {
-			temp1 /= 10;
-			temp2 /= 10;
-		}
-
-		frac_len = temp - 1;
-		temp = int_len - 1;
-
-		while(temp--) {
-			temp1 /= 10;
-			temp2 /= 10;
-		}
-
-		if (temp2 > temp1) {
-			frac /= 10;
-			if (exps == 1)
-				exp++;
-			else
-				exp--;
-		}
-
-		if (exp > frac_len || (!exps & (exp >= 5))) {
-			*tmp++ = digits[exp % 10];
-			exp /= 10;
-			if (!exp)
-				*tmp++ = '0';
-			else {
-				while (exp) {
-					*tmp++ = digits[exp % 10];
-					exp /= 10;
-				}
-			}
-
-			/* check exp sign */
-			if (exps)
-				*tmp++ ='+';
-			else
-				*tmp++ ='-';
-			*tmp++ ='e';
-		}
-
-		while (frac_len--) {
-			if (frac % 10 || !tz) {
-				tz = 0;
-				*tmp++ = digits[frac % 10];
-			}
-			frac /= 10;
-		}
-
-		if (exp) {
-			tz = 0;
-			*tmp++ = digits[frac % 10];
-			frac /= 10;
-			while (--exp)
-				*tmp++ = '0';
-		}
-
-		if (!tz)
-			*tmp++ = '.';
-
-		while (int_len--) {
-			*tmp++ = digits[frac % 10];
-			frac /= 10;
-		}
-		/* we need num32 to be 0 and num64 to not be 0 so the rest of the function won't mess our conversion */
-		num64 = 0x100000000;
-	}
-
-	if (flags & FLAG_FLOAT) {
-		float f = format_floatFromU32((uint32_t)num64);
-
-		if (f < 0) {
-			sign = '-';
-			f = -f;
-		}
-
-		float integral;
-		float frac = format_modff(f, &integral);
-
-		/* max decimal digits to fit into uint32 : 9 */
-		if (float_frac_len > 9)
-			float_frac_len = 9;
-
-		uint32_t frac32 = format_fracToU32(frac, float_frac_len, &integral);
-		int frac_left = float_frac_len;
-
-		while (frac_left-- > 0) {
-			*tmp++ = digits[frac32 % 10];
-			frac32 /= 10;
-		}
-
-		if (float_frac_len > 0 || (flags & FLAG_ALTERNATE))
-			*tmp++ = '.';
-
-		if (integral < 4294967296.0f)
-			num64 = (uint32_t)integral;
-		else {
-			float higher_part_f = (integral / 4294967296.0f);
-			uint32_t higher_part = (uint32_t)higher_part_f;
-			uint32_t lower_part = (uint32_t)(integral - (higher_part * 4294967296.0f));
-
-			num64 = (((uint64_t)higher_part) << 32) | lower_part;
-			flags |= FLAG_64BIT;
 		}
 	}
 
 	uint32_t num32 = (uint32_t)num64;
 	uint32_t num_high = (uint32_t)(num64 >> 32);
 
-	if (flags & FLAG_SIGNED) {
+	if ((flags & FLAG_SIGNED) != 0) {
 
-		if (flags & FLAG_64BIT) {
+		if ((flags & FLAG_64BIT) != 0) {
 
 			if ((int32_t)num_high < 0) {
 				num64 = -(int64_t)num64;
@@ -402,23 +793,24 @@ static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_
 		}
 
 		if (sign == 0) {
-			if (flags & FLAG_SPACE) {
-				sign = ' ';
-			}
-			else if (flags & FLAG_PLUS) {
+			if ((flags & FLAG_PLUS) != 0) {
 				sign = '+';
+			}
+			else if ((flags & FLAG_SPACE) != 0) {
+				sign = ' ';
 			}
 		}
 	}
 
-	if ((flags & FLAG_64BIT) && num_high == 0x0)
+	if (((flags & FLAG_64BIT) != 0) && (num_high == 0x0)) {
 		flags &= ~FLAG_64BIT;
+	}
 
 	if (num64 == 0) {
 		*tmp++ = '0';
 	}
-	else if (flags & FLAG_HEX) {
-		if (flags & FLAG_64BIT) {
+	else if ((flags & FLAG_HEX) != 0) {
+		if ((flags & FLAG_64BIT) != 0) {
 			int i;
 			for (i = 0; i < 8; ++i) {
 				*tmp++ = digits[num32 & 0x0f];
@@ -435,13 +827,13 @@ static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_
 				num32 >>= 4;
 			}
 		}
-		if (flags & FLAG_ALTERNATE) {
+		if ((flags & FLAG_ALTERNATE) != 0) {
 			memcpy(tmp, prefix, 2);
 			tmp += 2;
 		}
 	}
-	else if (flags & FLAG_OCT) {
-		if (flags & FLAG_64BIT) {
+	else if ((flags & FLAG_OCT) != 0) {
+		if ((flags & FLAG_64BIT) != 0) {
 			int i;
 			// 30 bits
 			for (i = 0; i < 10; ++i) {
@@ -464,12 +856,12 @@ static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_
 				num32 >>= 3;
 			}
 		}
-		if (flags & FLAG_ALTERNATE) {
+		if ((flags & FLAG_ALTERNATE) != 0) {
 			*tmp++  = '0';
 		}
 	}
 	else {
-		if (flags & FLAG_64BIT) { // TODO: optimize
+		if ((flags & FLAG_64BIT) != 0) {  // TODO: optimize
 			while (num64 != 0) {
 				*tmp++ = digits[num64 % 10];
 				num64 /= 10;
@@ -482,38 +874,24 @@ static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_
 			}
 		}
 	}
-
-	const int digits_cnt = tmp - tmp_buf;
-	int pad_len = min_number_len - digits_cnt - (sign ? 1 : 0);
-
-	/* pad, if needed */
-	if (pad_len > 0 && !(flags & FLAG_ZERO)) {
-		while (pad_len-- > 0)
-			feed(ctx, ' ');
-	}
-
-	if (sign)
-		feed(ctx, sign);
-
-	/* pad, if needed */
-	if (pad_len > 0 && (flags & FLAG_ZERO)) {
-		while (pad_len-- > 0)
-			feed(ctx, '0');
-	}
-
-	/* copy reversed */
-	while ((--tmp) >= tmp_buf)
-		feed(ctx, *tmp);
+	format_printBuffer(ctx, feed, flags, minFieldWidth, tmp, tmp_buf, sign);
 }
 
 
 void format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 {
+	uint64_t number;
+	const char *s;
+	char *p;
+	uint32_t flags, minFieldWidth;
+	int precision, length;
+	char c, fmt;
 	for (;;) {
-		char fmt = *format++;
+		fmt = *format++;
 
-		if (!fmt)
+		if (!fmt) {
 			break;
+		}
 
 		if (fmt != '%') {
 			feed(ctx, fmt);
@@ -521,66 +899,78 @@ void format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 		}
 
 		fmt = *format++;
-		if (fmt == 0) {
+		if (fmt == '\0') {
 			feed(ctx, '%');
 			break;
 		}
 
-		/* precission, padding (set default to 6 digits) */
-		uint32_t flags = 0, min_number_len = 0;
-		int	float_frac_len = -1;
+		/* precision, padding (set default to 6 digits) */
+		flags = 0, minFieldWidth = 0;
+		precision = -1;
 
 		for (;;) {
-			if (fmt == ' ')
+			if (fmt == ' ') {
 				flags |= FLAG_SPACE;
-			else if (fmt == '-')
+			}
+			else if (fmt == '-') {
 				flags |= FLAG_MINUS;
-			else if (fmt == '0')
+			}
+			else if (fmt == '0') {
 				flags |= FLAG_ZERO;
-			else if (fmt == '+')
+			}
+			else if (fmt == '+') {
 				flags |= FLAG_PLUS;
-			else if (fmt == '#')
+			}
+			else if (fmt == '#') {
 				flags |= FLAG_ALTERNATE;
-			else if (fmt == '*')
+			}
+			else if (fmt == '*') {
 				flags |= FLAG_FIELD_WIDTH_STAR;
-			else
+			}
+			else {
 				break;
+			}
 
 			fmt = *format++;
 		}
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
 		/* leading number digits-cnt */
-		while (fmt >= '0' && fmt <= '9') {
-			min_number_len = min_number_len * 10 + fmt - '0';
+		while ((fmt >= '0') && (fmt <= '9')) {
+			minFieldWidth = minFieldWidth * 10 + fmt - '0';
 			fmt = *format++;
 		}
 
-		if (flags & FLAG_FIELD_WIDTH_STAR)
-			min_number_len = va_arg(args, int);
+		if ((flags & FLAG_FIELD_WIDTH_STAR) != 0) {
+			minFieldWidth = va_arg(args, int);
+		}
 
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
 		/* fractional number digits-cnt (only a single digit is acceptable in this impl.) */
 		if (fmt == '.') {
-			float_frac_len = 0;
+			precision = 0;
 			fmt = *format++;
-			while (fmt >= '0' && fmt <= '9') {
-				float_frac_len  = float_frac_len * 10 + fmt - '0';
+			while ((fmt >= '0') && (fmt <= '9')) {
+				precision = precision * 10 + fmt - '0';
 				fmt = *format++;
 			}
 		}
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
 		if (fmt == '*') {
-			float_frac_len = va_arg(args, int);
+			precision = va_arg(args, int);
 			fmt = *format++;
 
-			if (fmt == 0)
+			if (fmt == '\0') {
 				break;
+			}
 		}
 
 		if (fmt == 'l') {
@@ -591,80 +981,69 @@ void format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 				fmt = *format++;
 			}
 		}
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
 		if (fmt == 'z') {
 			fmt = *format++;
-			if (sizeof(size_t) == sizeof(uint64_t))
+			if (sizeof(size_t) == sizeof(uint64_t)) {
 				flags |= FLAG_64BIT;
+			}
 		}
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
 		if (fmt == 'j') {
 			fmt = *format++;
 			flags |= FLAG_64BIT;
 		}
-		if (fmt == 0)
+		if (fmt == '\0') {
 			break;
+		}
 
-		uint64_t number = 0;
+		number = 0;
 		switch (fmt) {
 			case 's':
-			{
-				const char *s = va_arg(args, char *);
-				if (s == NULL)
+				flags &= ~(FLAG_ZERO | FLAG_ALTERNATE | FLAG_PLUS | FLAG_SPACE);
+				s = va_arg(args, char *);
+				if (s == NULL) {
 					s = "(null)";
-
-				int i, l;
-				if (min_number_len > 0) {
-					char *p = memchr(s, 0, min_number_len);
-					if (p != NULL)
-						l = p - s;
-					else
-						l = min_number_len;
-				} else {
-					l = strlen(s);
 				}
 
-				if (float_frac_len >= 0)
-					l = min(l, float_frac_len);
-
-				if (l < min_number_len && !(flags & FLAG_MINUS)) {
-					for(i = 0; i < (min_number_len - l); i++)
-						feed(ctx, ' ');
+				if (precision >= 0) {
+					p = memchr(s, 0, precision);
+					if (p != NULL) {
+						length = p - s;
+					}
+					else {
+						length = precision;
+					}
+				}
+				else {
+					length = strlen(s);
 				}
 
-				for(i = 0; i < l; i++)
-					feed(ctx, s[i]);
-
-				if (l < min_number_len && (flags & FLAG_MINUS)) {
-					for(i = 0; i < (min_number_len - l); i++)
-						feed(ctx, ' ');
-				}
-
+				format_printBuffer(ctx, feed, flags, minFieldWidth, s, s + length, 0);
 				break;
-			}
 			case 'c':
-			{
-				const char c = (char) va_arg(args,int);
-				feed(ctx, c);
-
+				c = (char)va_arg(args, int);
+				format_printBuffer(ctx, feed, flags, minFieldWidth, &c, &c + 1, 0);
 				break;
-			}
 			case 'p':
 				flags |= (FLAG_HEX | FLAG_NULLMARK | FLAG_ZERO);
-				if (sizeof(void *) == sizeof(uint64_t))
+				if (sizeof(void *) == sizeof(uint64_t)) {
 					flags |= FLAG_64BIT;
-				min_number_len = sizeof(void *) * 2;
+				}
+				minFieldWidth = sizeof(void *) * 2;
 				GET_UNSIGNED(number, flags, args);
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				format_sprintf_num(ctx, feed, number, flags, minFieldWidth, precision);
 				break;
 			case 'o':
 				flags |= FLAG_OCT;
 				GET_UNSIGNED(number, flags, args);
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				format_sprintf_num(ctx, feed, number, flags, minFieldWidth, precision);
 				break;
 			case 'X':
 				flags |= FLAG_LARGE_DIGITS;
@@ -672,25 +1051,34 @@ void format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 				flags |= FLAG_HEX;
 			case 'u':
 				GET_UNSIGNED(number, flags, args);
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				format_sprintf_num(ctx, feed, number, flags, minFieldWidth, precision);
 				break;
 			case 'd':
 			case 'i':
 				flags |= FLAG_SIGNED;
 				GET_SIGNED(number, flags, args);
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				format_sprintf_num(ctx, feed, number, flags, minFieldWidth, precision);
 				break;
+			case 'A':
+				flags |= FLAG_LARGE_DIGITS;
+			case 'a':
+				format_sprintfDouble(ctx, feed, (double)va_arg(args, double), flags, minFieldWidth, precision, 'a');
+				break;
+			case 'E':
+				flags |= FLAG_LARGE_DIGITS;
+			case 'e':
+				format_sprintfDouble(ctx, feed, (double)va_arg(args, double), flags, minFieldWidth, precision, 'e');
+				break;
+			case 'G':
+				flags |= FLAG_LARGE_DIGITS;
 			case 'g':
-				flags |= FLAG_DOUBLE;
-				float_frac_len = float_frac_len >= 0 ? float_frac_len : 6;
-				number = format_u64FromDouble((double)va_arg(args, double));
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				flags |= FLAG_NO_TRAILING_ZEROS;
+				format_sprintfDouble(ctx, feed, (double)va_arg(args, double), flags, minFieldWidth, precision, 'g');
 				break;
+			case 'F':
+				flags |= FLAG_LARGE_DIGITS;
 			case 'f':
-				flags |= FLAG_FLOAT;
-				float_frac_len = (float_frac_len >= 0) ? float_frac_len : 6;
-				number = format_u32FromFloat((float)va_arg(args, double));
-				format_sprintf_num(ctx, feed, number, flags, min_number_len, float_frac_len);
+				format_sprintfDouble(ctx, feed, (double)va_arg(args, double), flags, minFieldWidth, precision, 'f');
 				break;
 			case '%':
 				feed(ctx, '%');


### PR DESCRIPTION
- Remove invalid code that prints float
- Extract floating point printing to a new function
- Add support for conversion specifiers: %f, %F, %e, %E, %G, %a, %A
- Add support for flag: '-'
- Fix: Sign flag now works for positive values.
- Fix: double argument representing infinity is printed as 'inf' for %f, %e and %g conversion specifiers and as 'INF' for %F, %E and %G
- Fix: double argument representing NaN is printed as 'nan' for %f, %e and %g conversion specifiers and as 'NAN' for %F, %E and %G
- Fix: %g conversion specifier now doesn't ignore field width for {0.0, -0.0, NaN, infinity}
- Fix: conversion specifier %c used to ignore minimum field width
- Fix: conversion specifier %s used to truncate strings to minimum field width, instead of precision

DONE: RTOS-318

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
