### PR TITLE
scanf: add `%f` (aefgAEFG) conversion support and `L` length specifier.

### DIFF
--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -23,26 +23,26 @@
 #include <stdarg.h>
 
 
-#define	LONG		0x01	/* l: long or double */
-#define	SHORT		0x04	/* h: short */
-#define	SUPPRESS	0x08	/* *: suppress assignment */
-#define	POINTER		0x10	/* p: void * (as hex) */
-#define	NOSKIP		0x20	/* [ or c: do not skip blanks */
-#define	LONGLONG	0x400	/* ll: long long (+ deprecated q: quad) */
-#define	SHORTSHORT	0x4000	/* hh: char */
-#define	UNSIGNED	0x8000	/* %[oupxX] conversions */
+#define LONG       0x01   /* l: long or double */
+#define SHORT      0x04   /* h: short */
+#define SUPPRESS   0x08   /* *: suppress assignment */
+#define POINTER    0x10   /* p: void * (as hex) */
+#define NOSKIP     0x20   /* [ or c: do not skip blanks */
+#define LONGLONG   0x400  /* ll: long long (+ deprecated q: quad) */
+#define SHORTSHORT 0x4000 /* hh: char */
+#define UNSIGNED   0x8000 /* %[oupxX] conversions */
 
 
-#define	SIGNOK		0x40	/* +/- is (still) legal */
-#define	NDIGITS		0x80	/* no digits detected */
-#define	PFXOK		0x100	/* 0x prefix is (still) legal */
-#define	NZDIGITS	0x200	/* no zero digits detected */
+#define SIGNOK   0x40  /* +/- is (still) legal */
+#define NDIGITS  0x80  /* no digits detected */
+#define PFXOK    0x100 /* 0x prefix is (still) legal */
+#define NZDIGITS 0x200 /* no zero digits detected */
 
 
-#define	CT_CHAR		0	/* %c conversion */
-#define	CT_CCL		1	/* %[...] conversion */
-#define	CT_STRING	2	/* %s conversion */
-#define	CT_INT		3	/* %[dioupxX] conversion */
+#define CT_CHAR   0 /* %c conversion */
+#define CT_CCL    1 /* %[...] conversion */
+#define CT_STRING 2 /* %s conversion */
+#define CT_INT    3 /* %[dioupxX] conversion */
 
 
 static const unsigned char *__sccl(char *tab, const unsigned char *fmt)


### PR DESCRIPTION
Adds `%` (aefgAEFG) conversion support and `L` length specifier for `floats`, `doubles`, `long doubles`.

Fixes issue:
- https://github.com/phoenix-rtos/phoenix-rtos-project/issues/604

Note: This implementation depends on `strto(f|d|ld)` implementation for validation and parsing the input.

For hexadecimal fractional notation and NAN, INFINITY parsing support
refer to the [libphoenix/stdlib/strtod.c:`strto_any()`](https://github.com/phoenix-rtos/libphoenix/blob/961a7db311e2c4c880c372a6502b499a683f09d6/stdlib/strtod.c#L38-L39) implementation.

JIRA: RTOS-364

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order)
https://github.com/phoenix-rtos/libphoenix/pull/231
- [ ] I will merge this PR by myself when appropriate.
