### PR TITLE
stdio/scanf: Fix `%z` length modifier

### DIFF
--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -5,7 +5,7 @@
  *
  * scanf.c
  *
- * Copyright 2017, 2022 Phoenix Systems
+ * Copyright 2017, 2022-2023 Phoenix Systems
  * Author: Adrian Kepka, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -176,8 +176,10 @@ static int scanf_parse(char *ccltab, const char *inp, char const *fmt0, va_list 
 					continue;
 
 				case 'z':
-					if (sizeof(size_t) == sizeof(uint64_t))
+					if (sizeof(size_t) == sizeof(uint64_t)) {
 						flags |= LONGLONG;
+					}
+					continue;
 
 				case 'h':
 					if (flags & SHORT) {


### PR DESCRIPTION
Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/608

JIRA: RTOS-366

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
