### PR TITLE
stdlib/strtoul: Refactor implementation

### DIFF
--- a/stdlib/strtoul.c
+++ b/stdlib/strtoul.c
@@ -5,58 +5,99 @@
  *
  * strtoul, strtol
  *
- * Copyright 2017-2018 Phoenix Systems
- * Author: Jakub Sejdak, Pawel Pisarczyk, Michal Miroslaw
+ * Copyright 2017-2018, 2023 Phoenix Systems
+ * Author: Jakub Sejdak, Pawel Pisarczyk, Michal Miroslaw, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
  * %LICENSE%
  */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <limits.h>
 
 
 unsigned long int strtoul(const char *nptr, char **endptr, int base)
 {
-	unsigned long int t, v = 0;
+	unsigned long int cutoff, result = 0;
+	int cutlim, t, width = 0, negative = 0;
+	const char *sptr = nptr;
 
-	if ((base == 16 || base == 0) && nptr[0] == '0' && (nptr[1] | 0x20) == 'x') {
-		base = 16;
-		nptr += 2;
-	} else if (base == 0 && nptr[0] == '0')
-		base = 8;
-	else if (base == 0)
-		base = 10;
-
-	for (; isdigit(*nptr) || isalpha(*nptr); ++nptr) {
-		t = *nptr - '0';
-		if (t > 9)
-			t = (*nptr | 0x20) - 'a' + 10;
-
-		if (t >= (unsigned long int)base)
-			break;
-
-		v = (v * base) + t;
+	while (isspace(*sptr) != 0) {
+		sptr++;
 	}
 
-	if (endptr != NULL)
-		*endptr = (char *)nptr;
+	if (*sptr == '-') {
+		negative = 1;
+		sptr++;
+	}
+	else if (*sptr == '+') {
+		sptr++;
+	}
 
-	return v;
+	if ((base == 16 || base == 0) && sptr[0] == '0' && (sptr[1] | 0x20) == 'x') {
+		base = 16;
+		sptr += 2;
+	}
+	else if (base == 0 && sptr[0] == '0') {
+		base = 8;
+	}
+	else if (base == 0) {
+		base = 10;
+	}
+
+	if (base < 2 || base > (11 + 'z' - 'a')) {
+		errno = EINVAL;
+		return 0;
+	}
+
+	cutoff = (unsigned long int)(ULONG_MAX) / (unsigned long int)base;
+	cutlim = (unsigned long int)(ULONG_MAX) - (cutoff * (unsigned long int)base);
+
+	while (isalnum(*sptr) != 0) {
+		t = *sptr - '0';
+		if (t > 9) {
+			t = (*sptr | 0x20) - 'a' + 10;
+		}
+
+		if (t >= base) {
+			break;
+		}
+
+		if (result > cutoff || (result == cutoff && t > cutlim)) {
+			width = -1;
+			break;
+		}
+
+		result = result * (unsigned long int)base + t;
+		width++;
+		sptr++;
+	}
+
+	if (width < 0) {
+		errno = ERANGE;
+		result = ULONG_MAX;
+	}
+	else if (width == 0) {
+		errno = EINVAL;
+	}
+	else if (negative != 0) {
+		result = -result;
+	}
+
+	if (endptr != NULL) {
+		*endptr = (char *)(width > 0 ? sptr : nptr);
+	}
+
+	return result;
 }
 
 
 long int strtol(const char *nptr, char **endptr, int base)
 {
-	long int sign = 1;
-
-	if (*nptr == '-') {
-		sign = -1;
-		++nptr;
-	}
-
-	return sign * strtoul(nptr, endptr, base);
+	return (long int)strtoul(nptr, endptr, base);
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/603

This change refactors implementation of `strtoul()` in the following way
* the function returns either the result of the conversion or, if there was a leading minus sign the negation of the result of the conversion represented as an unsigned value unless the original (non-negated) value would overflow.
* in the latter case the `strtoul()` function returns `ULONG_MAX` and sets `errno` to `ERANGE`.
* any white space before the number is eaten.
* in case base value is unsupported errno is set to `EINVAL`.
* in case of no conversion was performed `EINVAL` errno is set.

JIRA: RTOS-367

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
