### PR TITLE
unistd/isatty: Fix `isatty()` on NOMMU arch

### DIFF
--- a/unistd/file.c
+++ b/unistd/file.c
@@ -5,7 +5,7 @@
  *
  * unistd (POSIX routines for file operations)
  *
- * Copyright 2017-2018 Phoenix Systems
+ * Copyright 2017-2023 Phoenix Systems
  * Author: Aleksander Kaminski, Pawel Pisarczyk, Kamil Amanowicz
  *
  * This file is part of Phoenix-RTOS.
@@ -484,14 +484,6 @@ int ptsname_r(int fd, char *buf, size_t buflen)
 
 int isatty(int fd)
 {
-/* FIXME remove after moving ioctls from devctls */
-#ifdef NOMMU
-	if (fd == 1 || fd == 0)
-		return 1;
-
-	return 0;
-#endif
-
 	struct termios t;
 	return tcgetattr(fd, &t) == 0;
 }


### PR DESCRIPTION
Remove obsolete `#if NOMMU .. #endif` in `isatty()` which is verified to work on all supported non-mmu targets which include:
* i.MX RT 117x, 106x
* stm32l4a6

The value returned by termios function `tcgetattr()` is correct in all cases on non-mmu targets if tried to open either tty or non-tty device. Function `tcgetattr()` sends `ioctl()` which is wrapped in a `mtDevCtl` message to the `libtty` (uart, console) driver. It will fail if the driver does not speak `libtty`.

JIRA: RTOS-369

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4a6, imxrt1176-nil, mimxrt1064-evk, stm32l4a6-nucleo, armv7a9-zynq7k-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
