### PR TITLE
stdlib: Fix unsetenv("") 

### DIFF
--- a/stdlib/env.c
+++ b/stdlib/env.c
@@ -139,28 +139,33 @@ static int _env_insert(int idx, char *v, unsigned allocated)
 	return 0;
 }
 
+
 int unsetenv(const char *name)
 {
-	if (!name || strchr(name, '=')) {
-		errno = EINVAL;
-		return -1;
+	char *v;
+	int idx;
+
+	if ((name == NULL) || (*name == '\0') || (strchr(name, '=') != NULL)) {
+		return set_errno(-EINVAL);
 	}
 
-	int idx;
-	char *v = _env_find(name, strlen(name), &idx);
-	if (!v)
+	v = _env_find(name, strlen(name), &idx);
+	if (v == NULL) {
 		return 0;
+	}
 
-	if (_string_allocated && _string_allocated[idx])
+	if ((_string_allocated != NULL) && (_string_allocated[idx] != 0)) {
 		free(environ[idx]);
+	}
 
 	_cnt--;
 
 	environ[idx] = environ[_cnt];
 	environ[_cnt] = NULL;
 
-	if (_string_allocated)
+	if (_string_allocated != NULL) {
 		_string_allocated[idx] = _string_allocated[_cnt];
+	}
 
 	return 0;
 }


### PR DESCRIPTION
`unsetenv()` should `return -1` and set `errno` to `EINVAL` when empty string is passed as argument.

JIRA: RTOS-402
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/631

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
