### PR TITLE
stdio/format: Fix incorrect behaviour for NULL

### DIFF
--- a/stdio/format.c
+++ b/stdio/format.c
@@ -800,9 +800,9 @@ static void format_sprintf_num(void *ctx, feedfunc feed, uint64_t num64, uint32_
 	uint32_t num_high = (uint32_t)(num64 >> 32);
 
 	if (((flags & FLAG_NULLMARK) != 0) && (num64 == 0)) {
-		for (i = 0; i < nilStringLength; i++) {
-			feed(ctx, nilString[i]);
-		}
+		flags &= ~FLAG_ZERO;
+		format_printBuffer(ctx, feed, flags, minFieldWidth, nilString, nilString + nilStringLength, sign);
+		return;
 	}
 
 	if ((flags & FLAG_SIGNED) != 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- Fix printf printing additional '0' with '(nil)'

fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/676

DONE: RTOS-427

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
