### PR TITLE
stdlib: fix initial seed for rand()

### DIFF
--- a/stdlib/rand.c
+++ b/stdlib/rand.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 
 
-unsigned int __randseed;
+static unsigned int __randseed = 1;
 
 int rand_r (unsigned int *seed)
 {


### PR DESCRIPTION
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/708

Makes `__randseed` variable `static`, and assigns it initial value of `1` as it is said in POSIX:
> If `srand()` is not called, the `rand()` seed is set as if `srand(1)` was called at program start.

JIRA: RTOS-445

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
