### PR TITLE
 math: Add optional per arch sqrt implementation 

### DIFF
--- a/include/arch/arm-imx/arch.h
+++ b/include/arch/arm-imx/arch.h
@@ -40,7 +40,9 @@
 
 static inline double __ieee754_sqrt(double x)
 {
+	/* clang-format off */
 	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+	/* clang-format on */
 
 	return x;
 }
@@ -50,7 +52,9 @@ static inline double __ieee754_sqrt(double x)
 
 static inline float __ieee754_sqrtf(float x)
 {
+	/* clang-format off */
 	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
+	/* clang-format on */
 
 	return x;
 }

--- a/include/arch/arm-imx/arch.h
+++ b/include/arch/arm-imx/arch.h
@@ -33,6 +33,17 @@
 #define __STRNCPY
 #define __MEMMOVE
 
+#if (__ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)) && (__ARM_FP & 8)
+#define __IEEE754_SQRT
+
+static inline double __ieee754_sqrt(double x)
+{
+	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+
+	return x;
+}
+#endif
+
 #define _PAGE_SIZE 0x1000
 #define SIZE_PAGE _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE
 

--- a/include/arch/arm-imx/arch.h
+++ b/include/arch/arm-imx/arch.h
@@ -33,12 +33,24 @@
 #define __STRNCPY
 #define __MEMMOVE
 
-#if (__ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)) && (__ARM_FP & 8)
+
+#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
+#if __ARM_FP & 8
 #define __IEEE754_SQRT
 
 static inline double __ieee754_sqrt(double x)
 {
 	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+
+	return x;
+}
+#endif
+
+#define __IEEE754_SQRTF
+
+static inline float __ieee754_sqrtf(float x)
+{
+	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
 
 	return x;
 }

--- a/include/arch/armv7/arch.h
+++ b/include/arch/armv7/arch.h
@@ -33,12 +33,23 @@
 #define __STRNCPY
 #define __MEMMOVE
 
-#if (__ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)) && (__ARM_FP & 8)
+#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
+#if __ARM_FP & 8
 #define __IEEE754_SQRT
 
 static inline double __ieee754_sqrt(double x)
 {
 	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+
+	return x;
+}
+#endif
+
+#define __IEEE754_SQRTF
+
+static inline float __ieee754_sqrtf(float x)
+{
+	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
 
 	return x;
 }

--- a/include/arch/armv7/arch.h
+++ b/include/arch/armv7/arch.h
@@ -39,7 +39,9 @@
 
 static inline double __ieee754_sqrt(double x)
 {
+	/* clang-format off */
 	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+	/* clang-format on */
 
 	return x;
 }
@@ -49,7 +51,9 @@ static inline double __ieee754_sqrt(double x)
 
 static inline float __ieee754_sqrtf(float x)
 {
+	/* clang-format off */
 	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
+	/* clang-format on */
 
 	return x;
 }

--- a/include/arch/armv7/arch.h
+++ b/include/arch/armv7/arch.h
@@ -33,6 +33,17 @@
 #define __STRNCPY
 #define __MEMMOVE
 
+#if (__ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)) && (__ARM_FP & 8)
+#define __IEEE754_SQRT
+
+static inline double __ieee754_sqrt(double x)
+{
+	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
+
+	return x;
+}
+#endif
+
 #define _PAGE_SIZE 0x200
 #define SIZE_PAGE _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE
 

--- a/include/arch/ia32/arch.h
+++ b/include/arch/ia32/arch.h
@@ -33,6 +33,7 @@ static inline double __ieee754_sqrt(double x)
 {
 	double result;
 
+	/* clang-format off */
 	__asm__ volatile ("fldl %1\n\t" /* put value */
 		"fsqrt\n\t"                 /* calc sqrt */
 		"fxtract\n\t"               /* extract exponent */
@@ -47,6 +48,7 @@ static inline double __ieee754_sqrt(double x)
 		"fstpl %0"                  /* get the result */
 		: "=m"(result)
 		: "m"(x));
+	/* clang-format on */
 
 	return result;
 }

--- a/include/math.h
+++ b/include/math.h
@@ -215,7 +215,6 @@ float fabsf(float x);
 #define logf(x)              ((float)log(x))
 #define log10f(x)            ((float)log10(x))
 #define powf(base, exponent) ((float)pow(base, exponent))
-#define sqrtf(x)             ((float)sqrt(x))
 #define roundf(x)            ((float)round(x))
 #define ceilf(x)             ((float)ceil(x))
 #define floorf(x)            ((float)floor(x))

--- a/math/power.c
+++ b/math/power.c
@@ -115,3 +115,24 @@ double sqrt(double x)
 	return xn * x;
 #endif
 }
+
+
+float sqrtf(float x)
+{
+#ifdef __IEEE754_SQRTF
+	float __ieee754_sqrtf(float x);
+
+	if (x < 0.0f) {
+		errno = EDOM;
+		return -NAN;
+	}
+
+	if (x == 0.0f || x == -0.0f) {
+		return x;
+	}
+
+	return __ieee754_sqrtf(x);
+#else
+	return (float)sqrt(x);
+#endif
+}


### PR DESCRIPTION
DONE: RTOS-495

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/738

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To provide simple, platform independent and hw accelerated if possible implementation of sqrt()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
