### PR TITLE
stdio: Reduce default getdelim buffer size

### DIFF
--- a/stdio/file.c
+++ b/stdio/file.c
@@ -981,8 +981,8 @@ ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream)
 	}
 
 	if (*lineptr == NULL || *n == 0) {
-		*n = BUFSIZ;
-		*lineptr = malloc(BUFSIZ);
+		*n = 120;
+		*lineptr = malloc(*n);
 		if (*lineptr == NULL) {
 			/* errno set by malloc */
 			return -1;


### PR DESCRIPTION
There is no relevance between getdelim default buffer size and default size of stream buffer size. Made getdelim default buffer size 120 bytes, as it's a most common value.

DONE: RTOS-501

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/753

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
