### PR TITLE
getopt: add support for :: optional arguments

### DIFF
--- a/unistd/getopt.c
+++ b/unistd/getopt.c
@@ -74,6 +74,10 @@ int getopt(int argc, char * const argv[], const char *optstring)
 			/* Argument in the same argv */
 			optarg = &argv[optind][optwhere];
 		}
+		else if (*(++optspec) == ':') {
+			/* Optional argument */
+			optarg = NULL;
+		}
 		else if (optind + 1 < argc) {
 			/* Argument in the next argv */
 			optarg = argv[optind + 1];

--- a/unistd/getopt.c
+++ b/unistd/getopt.c
@@ -39,11 +39,13 @@ int getopt(int argc, char * const argv[], const char *optstring)
 		optwhere = 1;
 	}
 
-	if (argc == 0 || argv == NULL || optind >= argc)
+	if ((argc == 0) || (argv == NULL) || (optind >= argc)) {
 		return -1;
+	}
 
-	if (argv[optind] == NULL || argv[optind][0] != '-' || argv[optind][1] == '\0')
+	if ((argv[optind] == NULL) || (argv[optind][0] != '-') || (argv[optind][1] == '\0')) {
 		return -1;
+	}
 
 	if ((argv[optind][1] == '-') && (argv[optind][2] == '\0')) {
 		optind++;
@@ -51,13 +53,15 @@ int getopt(int argc, char * const argv[], const char *optstring)
 	}
 
 	opt = argv[optind][optwhere++];
-	leading_colon = *optstring == ':';
+	leading_colon = ((*optstring == ':') ? 1 : 0);
 
 	optspec = strchr(optstring, opt);
-	if (optspec == NULL) { /* Unrecognized option */
+	if (optspec == NULL) {
+		/* Unrecognized option */
 		optopt = opt;
-		if (opterr && !leading_colon)
+		if ((opterr != 0) && (leading_colon == 0)) {
 			fprintf(stderr, "%s: illegal option -- %c\n", argv[0], opt);
+		}
 		if (argv[optind][optwhere] == '\0') {
 			optind++;
 			optwhere = 1;
@@ -66,27 +70,33 @@ int getopt(int argc, char * const argv[], const char *optstring)
 	}
 
 	if (*(++optspec) == ':') {
-		if (argv[optind][optwhere] != '\0') { /* Argument in the same argv */
+		if (argv[optind][optwhere] != '\0') {
+			/* Argument in the same argv */
 			optarg = &argv[optind][optwhere];
-
-		} else if (optind + 1 < argc) { /* Argument in the next argv */
+		}
+		else if (optind + 1 < argc) {
+			/* Argument in the next argv */
 			optarg = argv[optind + 1];
 			optind++;
-
-		} else { /* Argument not provided */
+		}
+		else {
+			/* Argument not provided */
 			optopt = opt;
 			optind++;
 			optwhere = 1;
-			if (leading_colon) {
+			if (leading_colon != 0) {
 				return ':';
-			} else {
-				if (opterr)
+			}
+			else {
+				if (opterr != 0) {
 					fprintf(stderr, "%s: option requires an argument -- %c\n", argv[0], opt);
+				}
 				return '?';
 			}
 		}
-
-	} else if (argv[optind][optwhere] != '\0') { /* More options in the same argv */
+	}
+	else if (argv[optind][optwhere] != '\0') {
+		/* More options in the same argv */
 		return opt;
 	}
 


### PR DESCRIPTION
Adds support for `getopt` extension: option characters followed by two colons.

A character followed by a `single colon` indicates that an argument is to follow the option on the command line.` Two colons` indicates that the argument is optional (this is transparent extension `not covered by POSIX`).

The extension is present in BSDs ([1](https://man.openbsd.org/getopt.3), [2](https://man.freebsd.org/cgi/man.cgi?getopt(3))) and GNU.

`getopt(argc, argv, "a::b:X")`

In the string above, option a will accept an optional argument. (Option requires an argument) Usage:

|Option syntax |Meaning |
| --- | --- |
|`-a` | OK, No argument provided (optional). |
|`-afoo` | OK, option `a` optional argument is `foo` |
|`-a` `foo` | Wrong, `no space allowed` with optional arguments, `foo` is `considered a non-option` argument. |
|`-bfoo` | OK, option `b` argument is `foo` (required). |
|`-b` `foo` | OK, option `b` argument is `foo` (required). |
|`-b` | Wrong, option `b` requires an argument.|

Since the argument is optional, you will have to check the value of `optarg` to see if it is a valid pointer (otherwise, it's `NULL`).

JIRA: RTOS-511

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
