### PR TITLE
complex: add commonly used complex number funcs

### DIFF
--- a/include/complex.h
+++ b/include/complex.h
@@ -1,0 +1,255 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * mathematical functions on complex numbers
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _COMPLEX_H_
+#define _COMPLEX_H_
+
+/* define complex numbers specifers */
+#define complex    _Complex
+#define _Complex_I 1.0fi
+#define I          _Complex_I
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+static inline double creal(double complex z)
+{
+	return (__real__(z));
+}
+
+
+static inline float crealf(float complex z)
+{
+	return (__real__(z));
+}
+
+
+static inline double cimag(double complex z)
+{
+	return (__imag__(z));
+}
+
+
+static inline float cimagf(float complex z)
+{
+	return (__imag__(z));
+}
+
+
+static inline double complex conj(double complex z)
+{
+	return __builtin_complex((__real__(z)), -(__imag__(z)));
+}
+
+
+static inline float complex conjf(float complex z)
+{
+	return __builtin_complex((__real__(z)), -(__imag__(z)));
+}
+
+
+double cabs(double complex);
+
+
+float cabsf(float complex);
+
+
+double carg(double complex);
+
+
+float cargf(float complex);
+
+
+double complex cexp(double complex);
+
+
+float complex cexpf(float complex);
+
+
+/*
+ * TODO: functions not yet implemented
+ */
+
+long double cabsl(long double complex);
+
+
+double complex cacos(double complex);
+
+
+float complex cacosf(float complex);
+
+
+double complex cacosh(double complex);
+
+
+float complex cacoshf(float complex);
+
+
+long double complex cacoshl(long double complex);
+
+
+long double complex cacosl(long double complex);
+
+
+long double cargl(long double complex);
+
+
+double complex casin(double complex);
+
+
+float complex casinf(float complex);
+
+
+double complex casinh(double complex);
+
+
+float complex casinhf(float complex);
+
+
+long double complex casinhl(long double complex);
+
+
+long double complex casinl(long double complex);
+
+
+double complex catan(double complex);
+
+
+float complex catanf(float complex);
+
+
+double complex catanh(double complex);
+
+
+float complex catanhf(float complex);
+
+
+long double complex catanhl(long double complex);
+
+
+long double complex catanl(long double complex);
+
+
+double complex ccos(double complex);
+
+
+float complex ccosf(float complex);
+
+
+double complex ccosh(double complex);
+
+
+float complex ccoshf(float complex);
+
+
+long double complex ccoshl(long double complex);
+
+
+long double complex ccosl(long double complex);
+
+
+long double complex cexpl(long double complex);
+
+
+long double cimagl(long double complex);
+
+
+double complex clog(double complex);
+
+
+float complex clogf(float complex);
+
+
+long double complex clogl(long double complex);
+
+
+long double complex conjl(long double complex);
+
+
+double complex cpow(double complex, double complex);
+
+
+float complex cpowf(float complex, float complex);
+
+
+long double complex cpowl(long double complex, long double complex);
+
+
+double complex cproj(double complex);
+
+
+float complex cprojf(float complex);
+
+
+long double complex cprojl(long double complex);
+
+
+long double creall(long double complex);
+
+
+double complex csin(double complex);
+
+
+float complex csinf(float complex);
+
+
+double complex csinh(double complex);
+
+
+float complex csinhf(float complex);
+
+
+long double complex csinhl(long double complex);
+
+
+long double complex csinl(long double complex);
+
+
+double complex csqrt(double complex);
+
+
+float complex csqrtf(float complex);
+
+
+long double complex csqrtl(long double complex);
+
+
+double complex ctan(double complex);
+
+
+float complex ctanf(float complex);
+
+
+double complex ctanh(double complex);
+
+
+float complex ctanhf(float complex);
+
+
+long double complex ctanhl(long double complex);
+
+
+long double complex ctanl(long double complex);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* end of _COMPLEX_H_ */

--- a/math/Makefile
+++ b/math/Makefile
@@ -4,4 +4,4 @@
 # Copyright 2012-2015, 2020 Phoenix Systems
 #
 
-OBJS += $(addprefix $(PREFIX_O)math/, trig.o power.o exp.o common.o hyper.o)
+OBJS += $(addprefix $(PREFIX_O)math/, trig.o power.o exp.o common.o complex.o hyper.o)

--- a/math/complex.c
+++ b/math/complex.c
@@ -1,0 +1,61 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * mathematical functions on complex numbers
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <math.h>
+#include <complex.h>
+
+
+double cabs(double complex z)
+{
+	/* FIXME: due to missing hypot() implementation, temporarily sqrt() is used */
+	return sqrt((creal(z) * creal(z)) + (cimag(z) * cimag(z)));
+}
+
+
+float cabsf(float complex z)
+{
+	/* FIXME: due to missing hypot() implementation, temporarily sqrtf() is used */
+	return sqrtf((crealf(z) * crealf(z)) + (cimagf(z) * cimagf(z)));
+}
+
+
+double carg(double complex z)
+{
+	return atan2(cimag(z), creal(z));
+}
+
+
+float cargf(float complex z)
+{
+	return atan2f(cimagf(z), crealf(z));
+}
+
+
+double complex cexp(double complex z)
+{
+	double re = creal(z);
+	double im = cimag(z);
+	double radius = exp(re);
+	return radius * cos(im) + radius * sin(im) * 1.0i;
+}
+
+
+float complex cexpf(float complex z)
+{
+	float re = crealf(z);
+	float im = cimagf(z);
+	float radius = expf(re);
+	return radius * cosf(im) + radius * sinf(im) * 1.0fi;
+}


### PR DESCRIPTION
Provide required `complex.h` function prototypes and commonly used functions.

`cabs()` and `cabsf()` implementations, to calculate distance, temporarily uses `sqrt()` instead of `hypot()` which is required but missing now.

In `cexp()` implementation Euler equation is used.

In reference to https://github.com/phoenix-rtos/phoenix-rtos-project/issues/785
JIRA: RTOS-528

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `ia32-generic`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
