### PR TITLE
socket: Align struct sa_familty to allow safe casting between all sockaddr_*

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -5,8 +5,8 @@
  *
  * sys/socket.h
  *
- * Copyright 2018 Phoenix Systems
- * Author: Jan Sikorski, Michal Miroslaw
+ * Copyright 2018, 2023 Phoenix Systems
+ * Author: Jan Sikorski, Michal Miroslaw, Aleksander Kaminski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -35,37 +35,37 @@
 #define PF_KEY    AF_KEY
 #define PF_PACKET AF_PACKET
 
-#define SOCK_STREAM 1
-#define SOCK_DGRAM 2
-#define SOCK_RAW 3
+#define SOCK_STREAM    1
+#define SOCK_DGRAM     2
+#define SOCK_RAW       3
 #define SOCK_SEQPACKET 4
-#define SOCK_RDM 5
+#define SOCK_RDM       5
 
-#define SOL_SOCKET 0xFFF
-#define SO_ACCEPTCONN 0x0002
-#define SO_BROADCAST 0x0020
-#define SO_DEBUG 0x0001
-#define SO_DONTROUTE 0x0010
-#define SO_ERROR 0x1007
-#define SO_KEEPALIVE 0x0008
-#define SO_LINGER 0x0080
-#define SO_OOBINLINE 0x0100
-#define SO_RCVBUF 0x1002
-#define SO_RCVLOWAT 0x1004
-#define SO_RCVTIMEO 0x1006
-#define SO_REUSEADDR 0x0004
-#define SO_SNDBUF 0x1001
-#define SO_SNDLOWAT 0x1003
-#define SO_SNDTIMEO 0x1005
-#define SO_TYPE 0x1008
+#define SOL_SOCKET      0xFFF
+#define SO_ACCEPTCONN   0x0002
+#define SO_BROADCAST    0x0020
+#define SO_DEBUG        0x0001
+#define SO_DONTROUTE    0x0010
+#define SO_ERROR        0x1007
+#define SO_KEEPALIVE    0x0008
+#define SO_LINGER       0x0080
+#define SO_OOBINLINE    0x0100
+#define SO_RCVBUF       0x1002
+#define SO_RCVLOWAT     0x1004
+#define SO_RCVTIMEO     0x1006
+#define SO_REUSEADDR    0x0004
+#define SO_SNDBUF       0x1001
+#define SO_SNDLOWAT     0x1003
+#define SO_SNDTIMEO     0x1005
+#define SO_TYPE         0x1008
 #define SO_BINDTODEVICE 0x100b
 
-#define MSG_OOB  0x01
-#define MSG_PEEK 0x02
+#define MSG_OOB      0x01
+#define MSG_PEEK     0x02
 #define MSG_DONTWAIT 0x08
 
-#define SHUT_RD 0
-#define SHUT_WR 1
+#define SHUT_RD   0
+#define SHUT_WR   1
 #define SHUT_RDWR 2
 
 #define SCM_RIGHTS 1
@@ -76,20 +76,20 @@ extern "C" {
 #endif
 
 
-typedef uint16_t sa_family_t;	// match lwIP size: u8 len + u8 family
+/* Match lwIP size: u8 len + u8 family. */
+typedef uint16_t sa_family_t;
 
 
 struct sockaddr {
 	sa_family_t sa_family;
-	char        sa_data[14];   // actual size may be bigger
-
+	char sa_data[14]; /* actual size may be bigger */
 };
 
 
 struct sockaddr_storage {
 	sa_family_t ss_family;
-	char        ss_data[128-sizeof(sa_family_t)];
-};
+	char ss_data[128 - sizeof(sa_family_t)]; /* e.g. struct sockaddr_un needs some space */
+} __attribute__((aligned(8)));               /* Align to allow safe sockaddr_* casting */
 
 
 struct linger {
@@ -97,25 +97,25 @@ struct linger {
 	int l_linger;
 };
 
-// has to be included after sockaddr is defined
+/* has to be included after sockaddr is defined */
 #include <sys/sockios.h>
 
 
 struct msghdr {
-	void         *msg_name;
-	socklen_t     msg_namelen;
+	void *msg_name;
+	socklen_t msg_namelen;
 	struct iovec *msg_iov;
-	int           msg_iovlen;
-	void         *msg_control;
-	socklen_t     msg_controllen;
-	int           msg_flags;
+	int msg_iovlen;
+	void *msg_control;
+	socklen_t msg_controllen;
+	int msg_flags;
 };
 
 
 struct cmsghdr {
 	socklen_t cmsg_len;
-	int       cmsg_level;
-	int       cmsg_type;
+	int cmsg_level;
+	int cmsg_type;
 };
 
 


### PR DESCRIPTION

DONE: RTOS-546

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/781

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
