### PR TITLE
math: Fix sqrt losing precision for a very small values of x

### DIFF
--- a/math/power.c
+++ b/math/power.c
@@ -81,7 +81,7 @@ double sqrt(double x)
 	return __ieee754_sqrt(x);
 #else
 	/* Use reciprocal square root method: */
-	double xn = (double)(1.0f / (float)x);
+	double xn = 1.0 / x;
 
 	/* IEEE-754 compliant: */
 	conv_t *init = (conv_t *)&xn;


### PR DESCRIPTION
DONE: RTOS-548

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/766

As it turns out, algorithm works just fine, whole problem was in this one line.
It was done to make single precision division instead of double precision to increase performance. But now it's of lower priority, as hardware accelerated implementation of sqrt is used on most targets. On targets with soft fpu it matters as little, as all float operations are low performance.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (PC).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
