### PR TITLE
unistd: add _SC_PAGESIZE entry to sysconf

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -32,8 +32,6 @@ extern "C" {
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-#define _SC_CLK_TCK 0
-#define _SC_PAGESIZE 1
 
 #define SEEK_SET 0
 #define SEEK_CUR 1
@@ -46,16 +44,21 @@ extern "C" {
 #define X_OK (1 << 0)
 
 
-enum {
-	_SC_OPEN_MAX,
-	_SC_IOV_MAX,
-	_SC_ATEXIT_MAX
-};
+#define _SC_OPEN_MAX   0
+#define _SC_IOV_MAX    1
+#define _SC_ATEXIT_MAX 2
+#define _SC_CLK_TCK    3
+#define _SC_PAGESIZE   4
+#define _SC_PAGE_SIZE  _SC_PAGESIZE /* spec. 1170 compatibility */
 
 
+extern long sysconf(int name);
+
+
+/* NOTE: Legacy from SUSv2, new applications should use sysconf(_SC_PAGESIZE) */
 static inline int getpagesize(void)
 {
-	return _PAGE_SIZE;
+	return (int)sysconf(_SC_PAGESIZE);
 }
 
 
@@ -194,9 +197,6 @@ extern int truncate(const char *path, off_t length);
 
 
 extern int ftruncate(int fildes, off_t length);
-
-
-extern long sysconf(int name);
 
 
 extern unsigned int alarm(unsigned int seconds);

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 
-#define STDIN_FILENO 0
+#define STDIN_FILENO  0
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
@@ -39,12 +39,11 @@ extern "C" {
 #define SEEK_CUR 1
 #define SEEK_END 2
 
-enum {
-	F_OK = 0,
-	R_OK = 1 << 2,
-	W_OK = 1 << 1,
-	X_OK = 1 << 0,
-};
+
+#define F_OK 0
+#define R_OK (1 << 2)
+#define W_OK (1 << 1)
+#define X_OK (1 << 0)
 
 
 enum {

--- a/unistd/sysconf.c
+++ b/unistd/sysconf.c
@@ -31,6 +31,9 @@ long sysconf(int name)
 	case _SC_ATEXIT_MAX:
 		/* we have no limit since we use lists */
 		return INT_MAX;
+	case _SC_PAGESIZE:
+		/* _SC_PAGE_SIZE is synonym */
+		return _PAGE_SIZE;
 	default:
 		errno = EINVAL;
 		return -1;


### PR DESCRIPTION
## Description / Motivation and Context
<!--- Describe your changes shortly -->

Portable applications should employ `sysconf(_SC_PAGESIZE)` instead of `getpagesize()`. Most systems allow the synonym `_SC_PAGE_SIZE` for `_SC_PAGESIZE` (both are specified in POSIX).

This change also replaces enums `_SC_*` with the corresponding definitions, and fixes the ambiguity of the previously defined `_SC_PAGESIZE` which overlapped the `_SC_IOV_MAX` enumeration.

JIRA: RTOS-577


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`, `imxrt1170-nil`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
