### PR TITLE
termios: Fix EINTR and errno handling

### DIFF
--- a/termios/termios.c
+++ b/termios/termios.c
@@ -20,11 +20,11 @@
 
 int tcgetattr(int fildes, struct termios *termios_p)
 {
-	int ret = ioctl(fildes, TCGETS, termios_p);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fildes, TCGETS, termios_p);
+	} while (ret < 0 && errno == EINTR);
+
 	return ret;
 }
 
@@ -47,55 +47,50 @@ int tcsetattr(int fildes, int optional_actions, const struct termios *termios_p)
 			return -1;
 	}
 
-	int ret = ioctl(fildes, cmd, termios_p);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fildes, cmd, termios_p);
+	} while (ret < 0 && errno == EINTR);
 
 	return ret;
 }
 
 int tcsendbreak(int fd, int duration)
 {
-	int ret = ioctl(fd, TCSBRK, duration);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TCSBRK, duration);
+	} while (ret < 0 && errno == EINTR);
 
 	return ret;
 }
 
 int tcflush(int fd, int queue_selector)
 {
-	int ret = ioctl(fd, TCFLSH, queue_selector);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TCFLSH, queue_selector);
+	} while (ret < 0 && errno == EINTR);
 
 	return ret;
 }
 
 int tcdrain(int fd)
 {
-	int ret = ioctl(fd, TCDRAIN, 0);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TCDRAIN, 0);
+	} while (ret < 0 && errno == EINTR);
 
 	return ret;
 }
 
 int tcsetpgrp(int fd, pid_t pgrp)
 {
-	int ret = ioctl(fd, TIOCSPGRP, &pgrp);
-	if (ret < 0) {
-		errno = -ret;
-		return -1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TIOCSPGRP, &pgrp);
+	} while (ret < 0 && errno == EINTR);
 
 	return ret;
 }
@@ -103,25 +98,23 @@ int tcsetpgrp(int fd, pid_t pgrp)
 pid_t tcgetpgrp(int fd)
 {
 	pid_t p;
-	int ret = ioctl(fd, TIOCGPGRP, &p);
-	if (ret < 0) {
-		errno = -ret;
-		return (pid_t)-1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TIOCGPGRP, &p);
+	} while (ret < 0 && errno == EINTR);
 
-	return p;
+	return ret < 0 ? (pid_t)-1 : p;
 }
 
 pid_t tcgetsid(int fd)
 {
 	pid_t p;
-	int ret = ioctl(fd, TIOCGSID, &p);
-	if (ret < 0) {
-		errno = -ret;
-		return (pid_t)-1;
-	}
+	int ret;
+	do {
+		ret = ioctl(fd, TIOCGSID, &p);
+	} while (ret < 0 && errno == EINTR);
 
-	return p;
+	return ret < 0 ? (pid_t)-1 : p;
 }
 
 void cfmakeraw(struct termios *termios_p)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
errno is set by ioctl, termios functions should not fail on EINTR

JIRA: RTOS-585
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
