### PR TITLE
make: remove direct target-arch include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ SIL ?= @
 MAKEFLAGS += --no-print-directory
 
 include ../phoenix-rtos-build/Makefile.common
-include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
 
 # establish sysroot
 SYSROOT := $(shell $(CC) $(CFLAGS) -print-sysroot)

--- a/Makefile.host
+++ b/Makefile.host
@@ -10,7 +10,6 @@ SIL ?= @
 MAKEFLAGS += --no-print-directory
 
 include ../phoenix-rtos-build/Makefile.common
-include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
 
 # establish sysroot
 LIBNAME := libphoenix.a


### PR DESCRIPTION
## Description

Not needed since a long time.


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

## Motivation and Context

JIRA: CI-334

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?

CI to pass: https://github.com/phoenix-rtos/phoenix-rtos-project/pull/823

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
