### PR TITLE
stdio.h: Remove duplicated ungetc() prototype

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -313,8 +313,6 @@ extern int getc_unlocked(FILE *stream);
 extern int getchar(void);
 extern int getchar_unlocked(void);
 
-/*  Pushes c back to stream, cast to unsigned char, where it is available for subsequent read operations */
-extern int ungetc(int c, FILE *stream);
 
 /*
  * Reads a line from stdin and stores it into the string pointed to by, str. It stops when either the newline character is read


### PR DESCRIPTION
DONE: RTOS-599

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/libphoenix/issues/250

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
