### PR TITLE
dirent: use common d_type defines

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -28,12 +28,25 @@ extern "C" {
 
 
 /* dirent types */
+/* FIXME: remove when dirent support would be straightened out in filesystems */
 enum {	dtDir = 0,
 		dtFile,
 		dtDev,
 		dtSymlink,
 		dtUnknown
 };
+
+/* NOTE: these values can't be changed as they are kept on FLASH (eg. in jffs2) */
+#define DT_UNKNOWN 0
+#define DT_FIFO    1
+#define DT_CHR     2
+#define DT_DIR     4
+#define DT_BLK     6
+#define DT_REG     8
+#define DT_LNK     10
+#define DT_SOCK    12
+#define DT_WHT     14
+
 
 struct dirent {
 	ino_t  d_ino;


### PR DESCRIPTION
## Description

- already used internally in jffs2
 - not part of POSIX but needed for interoperability with GNU tools
 - (especially autoconfig/automake in libstdc++ gcc-9.5.0)


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

## Motivation and Context

JIRA: CI-334


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
