### PR TITLE
time: fix incorrect rounding in time()

### DIFF
--- a/time/time.c
+++ b/time/time.c
@@ -90,7 +90,6 @@ time_t time(time_t *tp)
 	now += offs;
 
 	/* microseconds to seconds */
-	now += 500 * 1000;
 	now /= 1000 * 1000;
 
 	if (tp != NULL)


### PR DESCRIPTION
Before this fix `time()` function rounded timestamps to the nearest second, while other functions like `gettimeofday()` rounded it down. As a result, it was possible to get different timestamps for the same second depending on what function was used.

## Description
Changes rounding in `time()` function to be in line with other functions that retrieve the current time.

## Motivation and Context
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/621 - issue was caused by `date` command using `time()` and `touch` command using `gettimeofday()` to get the current time - but the two functions returned unexpectedly different results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
