### PR TITLE
ubsan: provide C handlers for libubsan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ include ../phoenix-rtos-build/Makefile.common
 SYSROOT := $(shell $(CC) $(CFLAGS) -print-sysroot)
 MULTILIB_DIR := $(shell $(CC) $(CFLAGS) -print-multi-directory)
 LIBC_INSTALL_DIR := $(SYSROOT)/lib/$(MULTILIB_DIR)
-LIBC_INSTALL_NAMES := libc.a libm.a libg.a libpthread.a
+LIBC_INSTALL_NAMES := libc.a libm.a libg.a libpthread.a libubsan.a
 HEADERS_INSTALL_DIR := $(SYSROOT)/usr/include
 LIBNAME := libphoenix.a
 
@@ -57,6 +57,7 @@ include termios/Makefile
 include time/Makefile
 include unistd/Makefile
 include wchar/Makefile
+include ubsan/Makefile
 
 #include test/Makefile
 

--- a/ubsan/Makefile
+++ b/ubsan/Makefile
@@ -1,0 +1,7 @@
+#
+# Makefile for libphoenix/ubsan
+#
+# Copyright 2023 Phoenix Systems
+#
+
+OBJS += $(addprefix $(PREFIX_O)ubsan/, ubsan.o)

--- a/ubsan/ubsan.c
+++ b/ubsan/ubsan.c
@@ -1,0 +1,246 @@
+/*
+ * Phoenix-RTOS
+ *
+ * ubsan
+ *
+ * Undefined Behavior Sanitization
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <unistd.h>
+
+
+struct source_location {
+	const char *file;
+	uint32_t line;
+	uint32_t column;
+};
+
+
+struct type_descriptor {
+	uint16_t type_kind;
+	uint16_t type_info;
+	char *type_name;
+};
+
+
+struct type_mismatch_data {
+	struct source_location loc;
+	struct type_descriptor *type;
+	unsigned long alignment;
+	unsigned char type_check_kind;
+};
+
+
+struct type_mismatch_data_v1 {
+	struct source_location loc;
+	struct type_descriptor *type;
+	unsigned char alignment;
+	unsigned char type_check_kind;
+};
+
+
+struct overflow_data {
+	struct source_location loc;
+	struct type_descriptor *type;
+};
+
+
+struct shift_out_of_bounds_data {
+	struct source_location loc;
+	struct type_descriptor *lhs_type;
+	struct type_descriptor *rhs_type;
+};
+
+
+struct out_of_bounds_data {
+	struct source_location loc;
+	struct type_descriptor *array_type;
+	struct type_descriptor *index_type;
+};
+
+
+struct unreachable_data {
+	struct source_location loc;
+};
+
+
+struct vla_bound_data {
+	struct source_location loc;
+	struct type_descriptor *type;
+};
+
+
+struct invalid_value_data {
+	struct source_location loc;
+	struct type_descriptor *type;
+};
+
+
+struct nonnull_arg_data {
+	struct source_location loc;
+};
+
+
+struct nonnull_return_data {
+	struct source_location loc;
+	struct source_location attr_loc;
+};
+
+
+struct invalid_builtin_data {
+	struct source_location loc;
+	uint8_t kind;
+};
+
+
+struct pointer_overflow_data {
+	struct source_location loc;
+};
+
+
+static void ubsan_print(struct source_location *loc, const char *message)
+{
+	const char *fmt = (isatty(STDERR_FILENO) != 0) ?
+		"\033[1m%s:%" PRIu32 ":%" PRIu32 ": \033[31mruntime error:\033[0;1m %s\033[0m\n" :
+		"%s:%" PRIu32 ":%" PRIu32 ": runtime error: %s\n";
+
+	(void)fprintf(stderr, fmt, loc->file, loc->line, loc->column, message);
+}
+
+
+void __ubsan_handle_add_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "addition overflow");
+}
+
+
+void __ubsan_handle_sub_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "subtraction overflow");
+}
+
+
+void __ubsan_handle_mul_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "multiplication overflow");
+}
+
+
+void __ubsan_handle_divrem_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "division overflow");
+}
+
+
+void __ubsan_handle_negate_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "negation overflow");
+}
+
+
+void __ubsan_handle_pointer_overflow(struct overflow_data *data)
+{
+	ubsan_print(&data->loc, "pointer overflow");
+}
+
+
+void __ubsan_handle_shift_out_of_bounds(struct shift_out_of_bounds_data *data)
+{
+	ubsan_print(&data->loc, "shift out of bounds");
+}
+
+
+void __ubsan_handle_out_of_bounds(struct out_of_bounds_data *data)
+{
+	ubsan_print(&data->loc, "array out of bounds");
+}
+
+
+void __ubsan_handle_load_invalid_value(struct invalid_value_data *data)
+{
+	ubsan_print(&data->loc, "invalid load value");
+}
+
+
+void __ubsan_handle_type_mismatch(struct type_mismatch_data *data, uintptr_t ptr)
+{
+	if (ptr == (uintptr_t)NULL) {
+		ubsan_print(&data->loc, "null pointer access");
+	}
+	else if ((data->alignment != 0) && ((ptr & (((uintptr_t)1 << data->alignment) - (uintptr_t)1)) != 0)) {
+		ubsan_print(&data->loc, "misaligned pointer is used");
+	}
+	else {
+		ubsan_print(&data->loc, "insufficient space for an object");
+	}
+}
+
+
+void __ubsan_handle_type_mismatch_v1(struct type_mismatch_data_v1 *data, uintptr_t ptr)
+{
+	if (ptr == (uintptr_t)NULL) {
+		ubsan_print(&data->loc, "null pointer access");
+	}
+	else if ((data->alignment != 0) && ((ptr & (((uintptr_t)1 << data->alignment) - (uintptr_t)1)) != 0)) {
+		ubsan_print(&data->loc, "misaligned pointer is used");
+	}
+	else {
+		ubsan_print(&data->loc, "insufficient space for an object");
+	}
+}
+
+
+void __ubsan_handle_vla_bound_not_positive(struct vla_bound_data *data)
+{
+	ubsan_print(&data->loc, "variable-length argument out of bounds");
+}
+
+
+void __ubsan_handle_nonnull_return(struct nonnull_return_data *data)
+{
+	ubsan_print(&data->loc, "null pointer returned from a function 'nonnull' specified");
+}
+
+
+void __ubsan_handle_nonnull_return_v1(struct nonnull_return_data *data, struct source_location *loc)
+{
+	ubsan_print(&data->loc, "null pointer returned from a function 'nonnull' specified");
+}
+
+
+#if __GCC_VERSION < 60000
+void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data, size_t arg_no)
+#else
+void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data)
+#endif
+{
+	ubsan_print(&data->loc, "non-null argument is null");
+}
+
+
+void __ubsan_handle_builtin_unreachable(struct unreachable_data *data)
+{
+	ubsan_print(&data->loc, "unreachable code reached");
+}
+
+
+void __ubsan_handle_invalid_builtin(struct invalid_builtin_data *data)
+{
+	ubsan_print(&data->loc, "invalid builtin");
+}
+
+
+void __ubsan_handle_missing_return(struct unreachable_data *data)
+{
+	ubsan_print(&data->loc, "missing return value");
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Provides small but full implementation of C runtime handlers for the undefined behavior sanitisation mechanism.

The output log is only colored when printing to a tty device, if the output is a file the log will be plain text.

The goal of the implementation is to provide a minimalist implementation of ubsan that can be run on small targets, that's why this implementation does not provide C++ instrumentation and other handlers like:
  `uptr __ubsan_vptr_type_cache[];`
  `void __ubsan_handle_dynamic_type_cache_miss(..);`
  `void __ubsan_handle_dynamic_type_cache_miss_abort(..);`

## Example output

Buggy snippet used in this example
```C
int main(int argc, char **argv)
{
    unsigned int v = 1 << 31;
    int tab[] = { 0 };
    return (tab[argc] != v) ? 0 : 1;
}
```

imxrt117x (ubsan implementation from this PR):
![2023-10-03-112508_1503x193_scrot](https://github.com/phoenix-rtos/libphoenix/assets/141153/d3206ee2-7ded-4105-a796-21eecb2833f4)


ia32-generic (ubsan implementation from this PR):

![2023-10-03-105754_738x231_scrot](https://github.com/phoenix-rtos/libphoenix/assets/141153/008a552c-ca49-40f7-94cf-28d2989a2b1b)

host-pc (default ubsan implementation provided with gcc):
![2023-10-03-105954_840x284_scrot](https://github.com/phoenix-rtos/libphoenix/assets/141153/0795cac3-b882-4843-8b62-15e24e897a8c)

## Section sizes

Comparison of the imxrt117x elf, compiled from the above "buggy example" (left with `-fsanitize=undefined`, right without)

![2023-10-03-113543_2245x651_scrot](https://github.com/phoenix-rtos/libphoenix/assets/141153/f64b7fee-66db-4d35-9924-368e4d46f72b)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

JIRA: RTOS-633


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`, `imxrt117x-nil`, `imxrt1064-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
