### PR TITLE
make: install relative symlinks to libphoenix.a instead of absolute ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,12 @@ install-libs: $(LIB_TARGETS)
 	mkdir -p "$(LIBC_INSTALL_DIR)"; \
 	rm -rf "$(LIBC_INSTALL_DIR)/crt0.o"; \
 	cp -a $^ "$(LIBC_INSTALL_DIR)"; \
-	for lib in $(LIBC_INSTALL_NAMES); do \
-		if [ ! -e "$(LIBC_INSTALL_DIR)/$$lib" ]; then \
-			ln -sf "$(LIBC_INSTALL_DIR)/libphoenix.a" "$(LIBC_INSTALL_DIR)/$$lib"; \
-		fi \
-	done
+	(cd $(LIBC_INSTALL_DIR) && \
+		for lib in $(LIBC_INSTALL_NAMES); do \
+			if [ ! -e "$$lib" ]; then \
+				ln -sf "libphoenix.a" "$$lib"; \
+			fi \
+	done)
 
 .PHONY: clean install install-headers install-libs
 clean:


### PR DESCRIPTION
## Description

Makes toolchain slightly more portable (moving toolchain would not invalidate embedded symlinks).

## Motivation and Context

JIRA: CI-334

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
