### PR TITLE
stubs: fix ttyname_r

### DIFF
--- a/posix/stubs.c
+++ b/posix/stubs.c
@@ -110,6 +110,10 @@ char *ttyname(int fildes)
 
 int ttyname_r(int fildes, char *name, size_t namesize)
 {
+	if (namesize > 0) {
+		name[0] = '\0';
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION



## Description

Functions using ttyname_r were experiencing out-of-bounds errors.
(eg. `login` from `busybox`)

## Motivation and Context

JIRA: RTOS-640


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
