### PR TITLE
assert: use abort() instead of exit()

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -28,9 +28,7 @@ extern "C" {
 
 #ifndef NDEBUG
 #define assert(__expr) \
-    ((__expr) \
-     ? (void)0 \
-     : ({ printf("Assertion '%s' failed in file %s:%d, function %s.\n", #__expr, __FILE__, __LINE__, __func__); exit(1);}))
+	((__expr) ? (void)0 : ({ printf("Assertion '%s' failed in file %s:%d, function %s.\n", #__expr, __FILE__, __LINE__, __func__); abort(); }))
 #else
 
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -122,7 +122,7 @@ extern size_t malloc_usable_size(void *ptr);
 
 
 /* Causes an abnormal program termination. */
-extern void abort(void);
+extern void abort(void) __attribute__((__noreturn__));
 
 
 /* Causes the specified function func to be called when the program terminates normally. */


### PR DESCRIPTION
## Motivation and Context

- atexit functions should not be called
- stream synchronization is optional (might lead to deadlocks)
- the exit code should indicate the program was killed with SIGABRT

JIRA: RTOS-668


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
