### PR TITLE
mktemp: Fix wrong divisor value for modulo operation

### DIFF
--- a/stdlib/mktemp.c
+++ b/stdlib/mktemp.c
@@ -5,8 +5,8 @@
  *
  * mktemp.c - create uniquely named files and directories
  *
- * Copyright 2018, 2020 Phoenix Systems
- * Author: Kamil Amanowicz, Lukasz Kosinski
+ * Copyright 2018, 2020, 2023 Phoenix Systems
+ * Author: Kamil Amanowicz, Lukasz Kosinski, Aleksander Kaminski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -28,35 +28,52 @@ static char pfcs[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345
 
 
 /* Generates a unique filename */
-static int mktemp(char *templt, int suffixlen)
+static int __mktemp(char *templt, int suffixlen)
 {
-	int i, len, rand, fd;
-	char *tail;
-	oid_t oid;
-
-	if ((templt == NULL) || (suffixlen < 0))
-		return -EINVAL;
-
-	len = strlen(templt);
-	tail = templt + len - suffixlen - 6;
-
-	if ((len < suffixlen + 6) || strncmp(tail, "XXXXXX", 6))
-		return -EINVAL;
-
-	if ((fd = open("/dev/urandom", O_RDONLY)) < 0)
-		return fd;
-
-	for (i = 0; i < 6; i++) {
-		read(fd, &rand, sizeof(rand));
-		tail[i] = pfcs[rand % sizeof(pfcs)];
+	if ((templt == NULL) || (suffixlen < 0)) {
+		return SET_ERRNO(-EINVAL);
 	}
 
+	int len = strlen(templt);
+	char *tail = templt + len - suffixlen - 6;
+
+	if ((len < (suffixlen + 6)) || (strncmp(tail, "XXXXXX", 6) != 0)) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	int fd = open("/dev/urandom", O_RDONLY);
+	if (fd < 0) {
+		/* errno set by open */
+		return fd;
+	}
+
+	int rand[6];
+	ssize_t left = sizeof(rand);
+	do {
+		ssize_t err;
+		do {
+			err = read(fd, rand + sizeof(rand) - left, left);
+		} while ((err < 0) && (errno == -EINTR));
+
+		if (err <= 0) {
+			close(fd);
+			/* errno set by read */
+			return -1;
+		}
+		left -= err;
+	} while (left != 0);
 	close(fd);
 
-	if (lookup(templt, &oid, NULL) == EOK)
-		return -EEXIST;
+	for (int i = 0; i < 6; ++i) {
+		tail[i] = pfcs[rand[i] % (sizeof(pfcs) - 1)];
+	}
 
-	return EOK;
+	oid_t oid;
+	if (lookup(templt, &oid, NULL) == 0) {
+		return SET_ERRNO(-EEXIST);
+	}
+
+	return 0;
 }
 
 
@@ -64,7 +81,7 @@ int mkostemps(char *templt, int suffixlen, int flags)
 {
 	int fd;
 
-	if (mktemp(templt, suffixlen) < 0)
+	if (__mktemp(templt, suffixlen) < 0)
 		return -1;
 
 	if ((fd = open(templt, (flags & ~0x03) | O_CREAT | O_RDWR | O_EXCL, DEFFILEMODE)) < 0)
@@ -94,7 +111,7 @@ int mkstemp(char *templt)
 
 char *mkdtemp(char *templt)
 {
-	if (mktemp(templt, 0) < 0)
+	if (__mktemp(templt, 0) < 0)
 		return NULL;
 
 	if (mkdir(templt, S_IRUSR | S_IWUSR | S_IXUSR) < 0)


### PR DESCRIPTION
DONE: RTOS-670

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/911

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
