### PR TITLE
lseek: Adapt to change in kernel API

### DIFF
--- a/unistd/file.c
+++ b/unistd/file.c
@@ -37,17 +37,26 @@ extern int sys_link(const char *path1, const char *path2);
 extern int sys_unlink(const char *path);
 extern int sys_pipe(int fildes[2]);
 extern int sys_fstat(int fd, struct stat *buf);
+extern int sys_lseek(int fildes, off_t *offset, int whence);
 
 WRAP_ERRNO_DEF(ssize_t, read, (int fildes, void *buf, size_t nbyte), (fildes, buf, nbyte))
 WRAP_ERRNO_DEF(ssize_t, write, (int fildes, const void *buf, size_t nbyte), (fildes, buf, nbyte))
 WRAP_ERRNO_DEF(int, close, (int fildes), (fildes))
 WRAP_ERRNO_DEF(int, ftruncate, (int fildes, off_t length), (fildes, length))
-WRAP_ERRNO_DEF(off_t, lseek, (int fildes, off_t offset, int whence), (fildes, offset, whence))
 WRAP_ERRNO_DEF(int, dup, (int fildes), (fildes))
 WRAP_ERRNO_DEF(int, dup2, (int fildes, int fildes2), (fildes, fildes2))
 WRAP_ERRNO_DEF(int, fsync, (int fildes), (fildes))
-// WRAP_ERRNO_DEF(int, pipe, (int fildes[2]), (fildes))
-// WRAP_ERRNO_DEF(int, fstat, (int fd, struct stat *buf), (fd, buf))
+
+
+off_t lseek(int fildes, off_t offset, int whence)
+{
+	int retval = sys_lseek(fildes, &offset, whence);
+	if (retval < 0) {
+		return (off_t)SET_ERRNO(retval);
+	}
+
+	return offset;
+}
 
 
 int pipe(int fildes[2])


### PR DESCRIPTION
JIRA: RTOS-397

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

tested in: https://github.com/phoenix-rtos/phoenix-rtos-project/pull/939

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
