### PR TITLE
unistd/crypt: fix hash byte order

### DIFF
--- a/unistd/crypt.c
+++ b/unistd/crypt.c
@@ -44,11 +44,11 @@ static unsigned char enc_res[31];
 
 
 typedef struct _sha1_ctx {
-	unsigned int len;					/* message length */
-	unsigned int h[5];					/* intermediate hash */
-	unsigned char blk[SHA1_BLOCK_SZ];	/* block */
-	unsigned int blk_idx;				/* block index */
-	unsigned int ext;					/* padding extended to the next block */
+	unsigned int len;                 /* message length */
+	unsigned int h[5];                /* intermediate hash */
+	unsigned char blk[SHA1_BLOCK_SZ]; /* block */
+	unsigned int blk_idx;             /* block index */
+	unsigned int ext;                 /* padding extended to the next block */
 } sha1_ctx;
 
 
@@ -79,14 +79,13 @@ static void sha1_processBlock(sha1_ctx *ctx)
 
 			ctx->blk[ctx->blk_idx] = 0x80;
 
-			while(++ctx->blk_idx < SHA1_BLOCK_SZ)
+			while (++ctx->blk_idx < SHA1_BLOCK_SZ)
 				ctx->blk[ctx->blk_idx] = 0x0;
-
 		}
 		else {
 			ctx->blk[ctx->blk_idx++] = 0x80;
 
-			while(ctx->blk_idx < 60)
+			while (ctx->blk_idx < 60)
 				ctx->blk[ctx->blk_idx++] = 0x0;
 
 			ctx->blk[ctx->blk_idx++] = (ctx->len >> 24) & 0xff;
@@ -101,7 +100,7 @@ static void sha1_processBlock(sha1_ctx *ctx)
 		W[t] = (ctx->blk[t * 4] & 0xff) << 24;
 		W[t] |= (ctx->blk[t * 4 + 1] & 0xff) << 16;
 		W[t] |= (ctx->blk[t * 4 + 2] & 0xff) << 8;
-		W[t] |= (ctx->blk[t * 4 + 3] & 0xff) ;
+		W[t] |= (ctx->blk[t * 4 + 3] & 0xff);
 	}
 
 	/* actual hashing */
@@ -163,7 +162,7 @@ static void sha1_process(sha1_ctx *ctx, const char *msg)
 {
 	size_t len = strlen(msg);
 
-	while(len--) {
+	while (len--) {
 		ctx->blk[ctx->blk_idx++] = *msg++ & 0xff;
 		ctx->len += 8;
 		if (ctx->blk_idx == SHA1_BLOCK_SZ)
@@ -217,7 +216,7 @@ static unsigned char *sha1_crypt(const char *key, const char *salt)
 
 
 static const unsigned char base64_table[65] =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 
 static void base64_encode(unsigned char *bytes, int len, unsigned char *res)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Previously data passed to `base64_encode` was casted directly from `unsigned int` to `unsigned char` array.
This PR fixes this by explicitly copying appropriate values of the bytes.
Hash is always base64-encoded as little endian.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`, `sparcv8leon3-gr716-mimas`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work
- [ ] I will merge this PR by myself when appropriate.
