### PR TITLE
stdlib/calloc: fix size overflow check

### DIFF
--- a/stdlib/malloc_dl.c
+++ b/stdlib/malloc_dl.c
@@ -467,18 +467,19 @@ void *malloc(size_t size)
 
 void *calloc(size_t nitems, size_t size)
 {
-	void *ptr;
-	uint64_t allocSize = (uint64_t)nitems * size;
-
-	if (allocSize > (uint64_t)UINT_MAX) {
+	if ((nitems != 0) && (size > SIZE_MAX / nitems)) {
 		errno = ENOMEM;
 		return NULL;
 	}
 
-	if ((ptr = malloc((size_t) allocSize)) == NULL)
-		return NULL;
+	size_t allocSize = nitems * size;
 
-	memset(ptr, 0, (size_t)allocSize);
+	void *ptr = malloc(allocSize);
+	if (ptr == NULL) {
+		return NULL;
+	}
+
+	memset(ptr, 0, allocSize);
 	return ptr;
 }
 


### PR DESCRIPTION
JIRA: RTOS-769

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fix overflow check on 64-bit targets, where `size_t * size_t` may not fit in `uint64_t`.

Division gets optimized by the compiler.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
