### PR TITLE
include/setjmp: add alignment to `__jmp_buf` definition

### DIFF
--- a/include/arch/armv7a/setjmp.h
+++ b/include/arch/armv7a/setjmp.h
@@ -31,7 +31,7 @@ struct __jmp_buf {
 	__u64 d[8];
 	__u32 fpscr;
 #endif
-} __attribute__((packed));
+} __attribute__((packed, aligned(8)));
 
 
 #endif

--- a/include/arch/armv7m/setjmp.h
+++ b/include/arch/armv7m/setjmp.h
@@ -31,7 +31,7 @@ struct __jmp_buf {
 	__u64 d[8];
 	__u32 fpscr;
 #endif
-} __attribute__((packed));
+} __attribute__((packed, aligned(8)));
 
 
 #endif

--- a/include/arch/ia32/setjmp.h
+++ b/include/arch/ia32/setjmp.h
@@ -26,7 +26,7 @@ struct __jmp_buf {
 	__u32 jmp;
 	__u32 ret;
 	__u32 sigMask;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 
 #endif

--- a/include/arch/riscv64/setjmp.h
+++ b/include/arch/riscv64/setjmp.h
@@ -28,7 +28,7 @@ struct __jmp_buf {
 	__u64 sigMsk;
 	__u64 f[12];
 	__u64 fcsr;
-} __attribute__((packed));
+} __attribute__((packed, aligned(8)));
 
 
 #endif

--- a/include/arch/sparcv8leon3/setjmp.h
+++ b/include/arch/sparcv8leon3/setjmp.h
@@ -26,7 +26,7 @@ struct __jmp_buf {
 	__u32 i[2];
 	__u32 sigFlg;
 	__u32 sigMsk;
-} __attribute__((packed));
+} __attribute__((packed, aligned(8)));
 
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add `aligned` attribute to `packed` `__jmp_buf` struct
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Misalignment caused abort exception on zynq7000
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
