### PR TITLE
sys: remove duplicate kernel definitions from events.h & file.h

### DIFF
--- a/include/sys/events.h
+++ b/include/sys/events.h
@@ -18,6 +18,7 @@
 #define _SYS_EVENTS_H_
 
 #include <sys/msg.h>
+#include <phoenix/events.h>
 
 
 #ifdef __cplusplus
@@ -26,9 +27,6 @@ extern "C" {
 
 
 enum { evtDataOut = 0, evtDataIn, evtError, evtGone };
-
-
-enum { evAdd = 0x1, evDelete = 0x2, evEnable = 0x4, evDisable = 0x8, evOneshot = 0x10, evClear = 0x20, evDispatch = 0x40 };
 
 
 typedef struct {

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -17,6 +17,7 @@
 #define _LIBPHOENIX_SYS_FILE_H_
 
 #include <sys/types.h>
+#include <phoenix/file.h>
 
 
 #ifdef __cplusplus
@@ -25,9 +26,6 @@ extern "C" {
 
 
 enum { otDir = 0, otFile, otDev, otSymlink, otUnknown };
-
-
-enum { atMode = 0, atUid, atGid, atSize, atBlocks, atIOBlock, atType, atPort, atPollStatus, atEventMask, atCTime, atMTime, atATime, atLinks, atDev };
 
 
 enum { mtMount = 0xf50, mtUmount, mtSync, mtStat, mtMountPoint };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/525
- [ ] I will merge this PR by myself when appropriate.
