### PR TITLE
stdint: fix definitions of minimum limits of exact-width integer types

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -56,10 +56,10 @@ typedef uint64_t uint_least64_t;
 
 /* 7.18.2.1 Limits of exact-width integer types */
 
-#define INT8_MIN  (-128)
-#define INT16_MIN (-32768)
-#define INT32_MIN (-2147483648)
-#define INT64_MIN (-INT64_C(9223372036854775808))
+#define INT8_MIN  (-127 - 1)
+#define INT16_MIN (-32767 - 1)
+#define INT32_MIN (-2147483647 - 1)
+#define INT64_MIN (-INT64_C(9223372036854775807) - 1)
 
 #define INT8_MAX  (127)
 #define INT16_MAX (32767)


### PR DESCRIPTION
JIRA: RTOS-872

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fix the definitions of minimum limits of exact-width integer types. Previous version caused the compiler to assign the value `9223372036854775808` type `unsigned long long` and not `long long` as requested by the `LL` suffix - in which it would not fit - which caused warning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
