### PR TITLE
arm: convert __ieee754_sqrt(f) to macros

### DIFF
--- a/include/arch/armv7a/arch.h
+++ b/include/arch/armv7a/arch.h
@@ -34,28 +34,13 @@
 #if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
 #if __ARM_FP & 8
 #define __IEEE754_SQRT
-
-static inline double __ieee754_sqrt(double x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif
 
 #define __IEEE754_SQRTF
-
-static inline float __ieee754_sqrtf(float x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrtf(x) ({ float a = (x); __asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(a) : "t"(a)); a; })
 #endif
+
 
 #define _PAGE_SIZE 0x1000
 #define SIZE_PAGE  _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE

--- a/include/arch/armv7m/arch.h
+++ b/include/arch/armv7m/arch.h
@@ -30,31 +30,17 @@
 #define __STRNCPY
 #define __MEMMOVE
 
+
 #if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
 #if __ARM_FP & 8
 #define __IEEE754_SQRT
-
-static inline double __ieee754_sqrt(double x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif
 
 #define __IEEE754_SQRTF
-
-static inline float __ieee754_sqrtf(float x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrtf(x) ({ float a = (x); __asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(a) : "t"(a)); a; })
 #endif
+
 
 #define _PAGE_SIZE 0x200
 #define SIZE_PAGE  _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE

--- a/include/arch/armv8m/arch.h
+++ b/include/arch/armv8m/arch.h
@@ -30,31 +30,17 @@
 #define __STRNCPY
 #define __MEMMOVE
 
+
 #if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
 #if __ARM_FP & 8
 #define __IEEE754_SQRT
-
-static inline double __ieee754_sqrt(double x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif
 
 #define __IEEE754_SQRTF
-
-static inline float __ieee754_sqrtf(float x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrtf(x) ({ float a = (x); __asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(a) : "t"(a)); a; })
 #endif
+
 
 #define _PAGE_SIZE 0x200
 #define SIZE_PAGE  _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE

--- a/include/arch/armv8r/arch.h
+++ b/include/arch/armv8r/arch.h
@@ -30,31 +30,17 @@
 #define __STRNCPY
 #define __MEMMOVE
 
+
 #if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
 #if __ARM_FP & 8
 #define __IEEE754_SQRT
-
-static inline double __ieee754_sqrt(double x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(x) : "w"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif
 
 #define __IEEE754_SQRTF
-
-static inline float __ieee754_sqrtf(float x)
-{
-	/* clang-format off */
-	__asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(x) : "t"(x));
-	/* clang-format on */
-
-	return x;
-}
+#define __ieee754_sqrtf(x) ({ float a = (x); __asm__ volatile ("vsqrt.f32 %0, %1" : "=t"(a) : "t"(a)); a; })
 #endif
+
 
 #define _PAGE_SIZE 0x1000
 #define SIZE_PAGE  _Pragma("GCC warning \"'SIZE_PAGE' is deprecated. Use _PAGE_SIZE from arch.h or PAGE_SIZE from limits.h (POSIX only)\"") _PAGE_SIZE

--- a/math/power.c
+++ b/math/power.c
@@ -76,8 +76,6 @@ double sqrt(double x)
 	}
 
 #ifdef __IEEE754_SQRT
-	double __ieee754_sqrt(double x);
-
 	return __ieee754_sqrt(x);
 #else
 	/* Use reciprocal square root method: */
@@ -120,8 +118,6 @@ double sqrt(double x)
 float sqrtf(float x)
 {
 #ifdef __IEEE754_SQRTF
-	float __ieee754_sqrtf(float x);
-
 	if (x < 0.0f) {
 		errno = EDOM;
 		return -NAN;


### PR DESCRIPTION
Declaring functions using double and float on arm in arch.h caused the definitions to spread to unexpected places. This deemed using "general-regs-only" in unit using basically anything from libphoenix impossible. Example of such unit is unwind-arm.c in libgcc for arm.

Declared as compound expressions to enforce inlining.

JIRA: RTOS-914

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
