### PR TITLE
unistd: fix _resolve_abspath() errno setting

### DIFF
--- a/unistd/dir.c
+++ b/unistd/dir.c
@@ -214,13 +214,16 @@ static int _resolve_abspath(char *path, char *result, int resolve_last_symlink, 
 		const size_t readlink_max_len = p - path;
 
 		/* (hackish) save some messsaging by not calling lstat, but directly readlink() and checking error code */
+		int errsave = errno;
 		ssize_t symlink_len = _readlink_abs(result, path, readlink_max_len);
 
 		if (symlink_len < 0) {
 			if (errno == EINVAL) { /* not a symlink */
+				errno = errsave;
 				continue;
 			}
 			else if ((errno == ENOENT) && (is_leaf != 0) && (allow_missing_leaf != 0)) { /* non-esixting leaf */
+				errno = errsave;
 				break;
 			}
 			else {
@@ -485,10 +488,6 @@ static ssize_t _readlink_abs(const char *path, char *buf, size_t bufsiz)
 	ret = msgSend(oid.port, &msg);
 	if (ret != EOK) {
 		return SET_ERRNO(ret);
-	}
-
-	if (msg.o.err < 0) {
-		return SET_ERRNO(msg.o.err);
 	}
 
 	if (msg.o.err < 0) {


### PR DESCRIPTION
In some cases an invalid errno set in _readlink_abs() propageted outside the function

JIRA: RTOS-981

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
