### PR TITLE
arch/sparcv8leon: increase PATH_MAX and NAME_MAX values

### DIFF
--- a/include/arch/sparcv8leon/limits.h
+++ b/include/arch/sparcv8leon/limits.h
@@ -57,8 +57,8 @@
 
 /*** POSIX-required defines ***/
 
-#define PATH_MAX    256  /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
-#define NAME_MAX    64   /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
+#define PATH_MAX    1024 /* Maximum number of bytes the implementation will store as a pathname in a user-supplied buffer of unspecified size, including the terminating null character. MIN: 256 */
+#define NAME_MAX    256  /* Maximum number of bytes in a filename (not including the terminating null of a filename string). MIN: 14 */
 #define ARG_MAX     4096 /* Maximum length of argument to the exec functions including environment data. MIN: 4096 */
 #define SYMLOOP_MAX 8    /* Maximum number of symbolic links that can be reliably traversed in the resolution of a pathname in the absence of a loop. MIN: 8 */
 


### PR DESCRIPTION
JIRA: RTOS-1010

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
psh tests create a file with name length of 90, which exceeded NAME_MAX define - which is not checked properly in libphoenix.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
