### PR TITLE
Fixes to allow enabling -Wundef

### DIFF
--- a/include/arch/armv7a/arch.h
+++ b/include/arch/armv7a/arch.h
@@ -31,8 +31,8 @@
 #define __MEMMOVE
 
 
-#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
-#if __ARM_FP & 8
+#if defined(__ARM_PCS_VFP) || (defined(__VFP_FP__) && !defined(__SOFTFP__))
+#if defined(__ARM_FP) && (__ARM_FP & 8) != 0
 #define __IEEE754_SQRT
 #define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif

--- a/include/arch/armv7m/arch.h
+++ b/include/arch/armv7m/arch.h
@@ -31,8 +31,8 @@
 #define __MEMMOVE
 
 
-#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
-#if __ARM_FP & 8
+#if defined(__ARM_PCS_VFP) || (defined(__VFP_FP__) && !defined(__SOFTFP__))
+#if defined(__ARM_FP) && (__ARM_FP & 8) != 0
 #define __IEEE754_SQRT
 #define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif

--- a/include/arch/armv7r/arch.h
+++ b/include/arch/armv7r/arch.h
@@ -31,8 +31,8 @@
 #define __MEMMOVE
 
 
-#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
-#if __ARM_FP & 8
+#if defined(__ARM_PCS_VFP) || (defined(__VFP_FP__) && !defined(__SOFTFP__))
+#if defined(__ARM_FP) && (__ARM_FP & 8) != 0
 #define __IEEE754_SQRT
 #define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif

--- a/include/arch/armv8m/arch.h
+++ b/include/arch/armv8m/arch.h
@@ -31,8 +31,8 @@
 #define __MEMMOVE
 
 
-#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
-#if __ARM_FP & 8
+#if defined(__ARM_PCS_VFP) || (defined(__VFP_FP__) && !defined(__SOFTFP__))
+#if defined(__ARM_FP) && (__ARM_FP & 8) != 0
 #define __IEEE754_SQRT
 #define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif

--- a/include/arch/armv8r/arch.h
+++ b/include/arch/armv8r/arch.h
@@ -31,8 +31,8 @@
 #define __MEMMOVE
 
 
-#if __ARM_PCS_VFP || (__VFP_FP__ && !__SOFTFP__)
-#if __ARM_FP & 8
+#if defined(__ARM_PCS_VFP) || (defined(__VFP_FP__) && !defined(__SOFTFP__))
+#if defined(__ARM_FP) && (__ARM_FP & 8) != 0
 #define __IEEE754_SQRT
 #define __ieee754_sqrt(x) ({ double a = (x); __asm__ volatile ("vsqrt.f64 %P0, %P1" : "=w"(a) : "w"(a)); a; })
 #endif

--- a/include/arch/ia32/arch.h
+++ b/include/arch/ia32/arch.h
@@ -23,7 +23,7 @@
 #define __MEMCPY
 #define __MEMSET
 
-#if (!__SOFTFP__)
+#ifndef __SOFTFP__
 #define __IEEE754_SQRT
 
 static inline double __ieee754_sqrt(double x)

--- a/include/arch/riscv64/arch.h
+++ b/include/arch/riscv64/arch.h
@@ -23,7 +23,7 @@
 #define __MEMCPY
 #define __MEMSET
 
-#if (!__SOFTFP__)
+#ifndef __SOFTFP__
 #define __IEEE754_SQRT
 
 static inline double __ieee754_sqrt(double x)

--- a/include/arch/sparcv8leon/arch.h
+++ b/include/arch/sparcv8leon/arch.h
@@ -28,7 +28,7 @@
 #define __STRCPY
 #define __STRNCPY
 
-#if (!_SOFT_FLOAT)
+#ifndef _SOFT_FLOAT
 #define __IEEE754_SQRT
 
 static inline double __ieee754_sqrt(double x)

--- a/regex/regcomp.c
+++ b/regex/regcomp.c
@@ -35,6 +35,9 @@
 
 #ifndef _NO_REGEX
 
+/* phoenix: define dead code guard correctly to prevent -Wundef errors */
+#define used 0
+
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)regcomp.c	8.5 (Berkeley) 3/20/94";
 #endif /* LIBC_SCCS and not lint */

--- a/ubsan/ubsan.c
+++ b/ubsan/ubsan.c
@@ -218,11 +218,7 @@ void __ubsan_handle_nonnull_return_v1(struct nonnull_return_data *data, struct s
 }
 
 
-#if __GCC_VERSION < 60000
-void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data, size_t arg_no)
-#else
 void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data)
-#endif
 {
 	ubsan_print(&data->loc, "non-null argument is null");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There are some useful warning flags, which are enabled in internal projects, like `-Wundef` and `-Wshadow`.

This commit allow libphoenix to be build with -Wundef without warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To enable `-Wundef` flag in the future

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: run compilation and some build-time checks on armv7m4-stm32l4x6-nucleo armv7m7-imxrt117x-evk sparcv8leon-generic-qemu riscv64-noelv-fpga riscv64-generic-qemu armv8r52-mps3an536-qemu armv8m33-mcxn94x-frdm aarch64a53-zynqmp-qemu armv7a9-zynq7000-qemu armv7a7-imx6ull-evk ia32-generic-qemu. Not run any of target after changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
