### PR TITLE
!perf: generalize perf syscalls

### DIFF
--- a/include/sys/perf.h
+++ b/include/sys/perf.h
@@ -1,0 +1,38 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * sys/perf
+ *
+ * Copyright 2025 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIBPHOENIX_SYS_PERF_H_
+#define _LIBPHOENIX_SYS_PERF_H_
+
+#include <phoenix/perf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+extern int perf_start(perf_mode_t mode, unsigned pid);
+
+
+extern int perf_read(perf_mode_t mode, void *buffer, size_t bufsz);
+
+
+extern int perf_finish(perf_mode_t mode);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -49,15 +49,6 @@ extern void _errno_new(struct __errno_t *e);
 extern void _errno_remove(struct __errno_t *e);
 
 
-extern int perf_start(unsigned pid);
-
-
-extern int perf_read(void *buffer, size_t bufsz);
-
-
-extern int perf_finish(void);
-
-
 extern int gettid(void);
 
 


### PR DESCRIPTION
Previous perf semantics are preserved by passing `perf_mode_threads`

JIRA: RTOS-1057

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/661
- [ ] I will merge this PR by myself when appropriate.
