### PR TITLE
signal: fix signal trampoline for aarch64

### DIFF
--- a/arch/aarch64/signal.S
+++ b/arch/aarch64/signal.S
@@ -20,11 +20,12 @@
 .globl _signal_trampoline
 .type _signal_trampoline, %function
 _signal_trampoline:
-	ldr x0, [sp], 8 /* signal number */
+	/* Signal number, oldmask - keep stack aligned to 16 */
+	ldp x0, x19, [sp], #0x10
 	bl _signal_handler
 
-	ldp x0, x1, [sp], #0x10 /* oldmask, cpu_context_t *  */
-	ldp x2, x3, [sp], #0x10 /* pc, sp */
-	ldr x4, [sp], #0x10 /* psr, skip padding at the end */
+	mov x0, x19             /* move oldmask to x0 */
+	ldp x1, x2, [sp], #0x10 /* cpu_context_t *, pc */
+	ldp x3, x4, [sp], #0x10 /* sp, psr */
 	bl sigreturn
 .size _signal_trampoline, .-_signal_trampoline


### PR DESCRIPTION
Previous solution resulted in stack not being aligned to 16. Qemu doesn't check stack alignment correctness due to performance reasons - that's why it passed the tests.

JIRA: RTOS-1059

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
