### PR TITLE
unistd/alarm: fix alarm() after fork

### DIFF
--- a/unistd/alarm.c
+++ b/unistd/alarm.c
@@ -85,5 +85,5 @@ unsigned int alarm(unsigned int seconds)
 	mutexUnlock(alarm_common.lock);
 	condSignal(alarm_common.cond);
 
-	return previous ? (previous - now) / (1000 * 1000) : 0;
+	return (previous && previous > now) ? (previous - now + (1000 * 1000 - 1)) / (1000 * 1000) : 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- fix alarm() return value to match POSIX requirement of returning nonzero value if alarm is set.
- fix after fork alarm thread by spawning new ib atfork handler

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves phoenix-rtos/phoenix-rtos-project#1241

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
