### PR TITLE
time/clock_gettime: add handling of CLOCK_THREAD_CPUTIME_ID flag

### DIFF
--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -86,6 +86,9 @@ static inline int beginthread(void (*start)(void *), unsigned int priority, void
 extern int threadsinfo(int n, threadinfo_t *info);
 
 
+extern time_t getThreadCpuTime(void);
+
+
 extern int priority(int priority);
 
 

--- a/include/time.h
+++ b/include/time.h
@@ -17,7 +17,7 @@
 #define _LIBPHOENIX_TIME_H_
 
 
-#define SECS_TO_USECS_T(secs) (1000000ULL * (secs))
+#define SECS_TO_USECS_T(secs)   (1000000ULL * (secs))
 #define MSECS_TO_USECS_T(msecs) (1000ULL * (msecs))
 
 #include <sys/types.h>
@@ -26,9 +26,10 @@
 #define CLOCKS_PER_SEC 1000000
 
 
-#define CLOCK_MONOTONIC     0
-#define CLOCK_MONOTONIC_RAW 1
-#define CLOCK_REALTIME      2
+#define CLOCK_MONOTONIC         0
+#define CLOCK_MONOTONIC_RAW     1
+#define CLOCK_REALTIME          2
+#define CLOCK_THREAD_CPUTIME_ID 3
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA: RTOS-1088

## Description
<!--- Describe your changes shortly -->
Add handling of missing CLOCK_THREAD_CPUTIME_ID flag in clock_gettime function.
This allows apps to know how much time did a thread spend on a CPU.

## Motivation and Context
Missing functionality useful for porting apps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu, armv7a9-zynq7000-qemu)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/692
- [ ] I will merge this PR by myself when appropriate.
