### PR TITLE
Change macro definitions in termios to match corresponding baudrates

### DIFF
--- a/include/termios.h
+++ b/include/termios.h
@@ -117,28 +117,32 @@ enum {
 	FF1 = 1 << 28,
 };
 
-/* baud rate */
-/* these need to be define's as various programs test them in preprocessor macros */
+
+/**
+ * baud rate macros with values corresponding to actual bps
+ * those macro values must fit into speed_t type
+ * these need to be define's as various programs test them in preprocessor macros
+ */
 #define B0      0
-#define B50     1
-#define B75     2
-#define B110    3
-#define B134    4
-#define B150    5
-#define B200    6
-#define B300    7
-#define B600    8
-#define B1200   9
-#define B1800   10
-#define B2400   11
-#define B4800   12
-#define B9600   13
-#define B19200  14
-#define B38400  15
-#define B57600  16
-#define B115200 17
-#define B230400 18
-#define B460800 19
+#define B50     50
+#define B75     75
+#define B110    110
+#define B134    134
+#define B150    150
+#define B200    200
+#define B300    300
+#define B600    600
+#define B1200   1200
+#define B1800   1800
+#define B2400   2400
+#define B4800   4800
+#define B9600   9600
+#define B19200  19200
+#define B38400  38400
+#define B57600  57600
+#define B115200 115200
+#define B230400 230400
+#define B460800 460800
 
 
 /* c_cflag */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Speed macros' values are changed to actual baudrates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change makes it more convenient to configure baudrates as now user can either use predefined macro with literal value or actual baudrate for example, using macro B115200 is exactly the same as using value 115200. This allows also to use values beyond macro restrictions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

 - https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/585
