### PR TITLE
Backport io changes (possibility of disabling float and scanf fixes) to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ endif
 
 CFLAGS += -Iinclude -fno-builtin-malloc
 
+# FIXME: Find a proper way to provide different versions of libphoenix to projects
+ifdef LIBPHOENIX_IO_NO_FLOAT
+CFLAGS += -DIO_NO_FLOAT
+endif
 
 OBJS :=
 # crt0.o should have all necessary initialization + call to main()

--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -630,6 +630,7 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				break;
 
 			case CT_FLOAT: {
+#ifndef IO_NO_FLOAT
 				union {
 					float f;
 					double d;
@@ -686,6 +687,9 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				}
 
 				break;
+#else
+				return (nconversions != 0 ? nassigned : -1);
+#endif
 			}
 
 			default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
https://github.com/phoenix-rtos/libphoenix/pull/437
https://github.com/phoenix-rtos/libphoenix/pull/370 - scanf part
https://github.com/phoenix-rtos/libphoenix/pull/357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
