### PR TITLE
Backport io changes (possibility of disabling float and scanf fixes) to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ endif
 
 CFLAGS += -Iinclude -fno-builtin-malloc
 
+# FIXME: Find a proper way to provide different versions of libphoenix to projects
+ifdef LIBPHOENIX_IO_NO_FLOAT
+CFLAGS += -DIO_NO_FLOAT
+endif
 
 OBJS :=
 # crt0.o should have all necessary initialization + call to main()

--- a/stdio/format.c
+++ b/stdio/format.c
@@ -112,6 +112,54 @@ static const char smallDigits[] = "0123456789abcdef";
 static const char largeDigits[] = "0123456789ABCDEF";
 
 
+static void format_printBuffer(void *ctx, feedfunc feed, uint32_t flags, int minFieldWidth, const char *start, const char *end, char sign)
+{
+	const int digits_cnt = start > end ? start - end : end - start;
+	int pad_len = minFieldWidth - digits_cnt - (sign ? 1 : 0);
+	/* If FLAG_ZERO and FLAG_MINUS both appear, then FLAG_ZERO is ignored */
+	if ((flags & FLAG_MINUS) != 0) {
+		flags &= ~FLAG_ZERO;
+	}
+
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) == 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, ' ');
+		}
+	}
+
+	if (sign != 0) {
+		feed(ctx, sign);
+	}
+
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) != 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, '0');
+		}
+	}
+
+	/* copy */
+	if (start > end) {
+		while ((--start) >= end) {
+			feed(ctx, *start);
+		}
+	}
+	else {
+		while (start < end) {
+			feed(ctx, *start++);
+		}
+	}
+
+	/* pad, if needed */
+	if ((pad_len > 0) && ((flags & FLAG_MINUS) != 0)) {
+		while (pad_len-- > 0) {
+			feed(ctx, ' ');
+		}
+	}
+}
+
+
 static inline int format_bufferInit(struct buffer *buff, size_t size)
 {
 	char *data = malloc(size);
@@ -247,54 +295,6 @@ static int format_bigdoubleLoad(struct bigdouble *result, double val)
 		result->firstIntegerBit = DOUBLE_EXP_SHIFT - exp;
 	}
 	return res;
-}
-
-
-static void format_printBuffer(void *ctx, feedfunc feed, uint32_t flags, int minFieldWidth, const char *start, const char *end, char sign)
-{
-	const int digits_cnt = start > end ? start - end : end - start;
-	int pad_len = minFieldWidth - digits_cnt - (sign ? 1 : 0);
-	/* If FLAG_ZERO and FLAG_MINUS both appear, then FLAG_ZERO is ignored */
-	if ((flags & FLAG_MINUS) != 0) {
-		flags &= ~FLAG_ZERO;
-	}
-
-	/* pad, if needed */
-	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) == 0)) {
-		while (pad_len-- > 0) {
-			feed(ctx, ' ');
-		}
-	}
-
-	if (sign != 0) {
-		feed(ctx, sign);
-	}
-
-	/* pad, if needed */
-	if ((pad_len > 0) && ((flags & FLAG_MINUS) == 0) && ((flags & FLAG_ZERO) != 0)) {
-		while (pad_len-- > 0) {
-			feed(ctx, '0');
-		}
-	}
-
-	/* copy */
-	if (start > end) {
-		while ((--start) >= end) {
-			feed(ctx, *start);
-		}
-	}
-	else {
-		while (start < end) {
-			feed(ctx, *start++);
-		}
-	}
-
-	/* pad, if needed */
-	if ((pad_len > 0) && ((flags & FLAG_MINUS) != 0)) {
-		while (pad_len-- > 0) {
-			feed(ctx, ' ');
-		}
-	}
 }
 
 

--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -48,6 +48,7 @@
 #define CT_STRING 2 /* %s conversion */
 #define CT_INT    3 /* %[dioupxX] conversion */
 #define CT_FLOAT  4 /* %[aefgAEFG] conversion */
+#define CT_NONE   5 /* No conversion (ex. %n) */
 
 
 static const unsigned char *__sccl(char *tab, const unsigned char *fmt)
@@ -113,7 +114,7 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 	char *p, *p0;
 	char buf[32];
 
-	static short basefix[17] = { 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+	static const short basefix[17] = { 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 
 	*inr = strlen(inp);
 
@@ -226,6 +227,8 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				case '9':
 					width = width * 10 + c - '0';
 					continue;
+				default:
+					break;
 			}
 
 			/*
@@ -298,7 +301,7 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				case 'n':
 					nconversions++;
 					if ((flags & SUPPRESS) != 0) {
-						continue;
+						break;
 					}
 					if ((flags & SHORTSHORT) != 0) {
 						*va_arg(ap, char *) = nread;
@@ -318,7 +321,12 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					else {
 						*va_arg(ap, int *) = nread;
 					}
-					continue;
+					c = CT_NONE;
+					break;
+				default:
+					c = CT_NONE;
+					/* TODO: Handle this */
+					break;
 			}
 
 			break;
@@ -674,6 +682,8 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				nconversions++;
 				break;
 
+			case CT_NONE:
+				break;
 			default:
 				break;
 		}

--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -59,13 +59,15 @@ static const unsigned char *__sccl(char *tab, const unsigned char *fmt)
 		v = 1;
 		c = *fmt++;
 	}
-	else
+	else {
 		v = 0;
+	}
 
 	memset(tab, (uint8_t)v, 256);
 
-	if (c == 0)
+	if (c == 0) {
 		return (fmt - 1);
+	}
 
 	v = 1 - v;
 	tab[c] = v;
@@ -78,7 +80,7 @@ static const unsigned char *__sccl(char *tab, const unsigned char *fmt)
 
 			case '-':
 				n = *fmt;
-				if (n == ']' || n < c) {
+				if ((n == ']') || (n < c)) {
 					c = '-';
 					tab[c] = v;
 					break;
@@ -121,11 +123,12 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 	base = 0;
 	for (;;) {
 		c = *fmt++;
-		if (c == 0)
+		if (c == 0) {
 			return (nassigned);
+		}
 
-		if (isspace(c)) {
-			while (*inr > 0 && isspace(*inp)) {
+		if (isspace(c) != 0) {
+			while ((*inr > 0) && (isspace(*inp) != 0)) {
 				nread++;
 				(*inr)--;
 				inp++;
@@ -134,11 +137,13 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 		}
 
 		if (c != '%') {
-			if (*inr <= 0)
+			if (*inr <= 0) {
 				return (nconversions != 0 ? nassigned : -1);
+			}
 
-			if (*inp != c)
+			if (*inp != c) {
 				return nassigned;
+			}
 
 			nread++;
 			(*inr)--;
@@ -151,11 +156,13 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 		for (;;) {
 			c = *fmt++;
 			if (c == '%') {
-				if (*inr <= 0)
+				if (*inr <= 0) {
 					return (nconversions != 0 ? nassigned : -1);
+				}
 
-				if (*inp != c)
+				if (*inp != c) {
 					return nassigned;
+				}
 
 				nread++;
 				(*inr)--;
@@ -169,12 +176,13 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					continue;
 
 				case 'l':
-					if (flags & LONG) {
+					if ((flags & LONG) != 0) {
 						flags &= ~LONG;
 						flags |= LONGLONG;
 					}
-					else
+					else {
 						flags |= LONG;
+					}
 					continue;
 
 				case 'L':
@@ -197,12 +205,13 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					continue;
 
 				case 'h':
-					if (flags & SHORT) {
+					if ((flags & SHORT) != 0) {
 						flags &= ~SHORT;
 						flags |= SHORTSHORT;
 					}
-					else
+					else {
 						flags |= SHORT;
+					}
 					continue;
 
 				case '0':
@@ -288,38 +297,49 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 
 				case 'n':
 					nconversions++;
-					if (flags & SUPPRESS)
+					if ((flags & SUPPRESS) != 0) {
 						continue;
-					if (flags & SHORTSHORT)
+					}
+					if ((flags & SHORTSHORT) != 0) {
 						*va_arg(ap, char *) = nread;
-					else if (flags & SHORT)
+					}
+					else if ((flags & SHORT) != 0) {
 						*va_arg(ap, short *) = nread;
-					else if (flags & LONG)
+					}
+					else if ((flags & LONG) != 0) {
 						*va_arg(ap, long *) = nread;
-					else if (flags & LONGLONG)
+					}
+					else if ((flags & LONGLONG) != 0) {
 						*va_arg(ap, long long *) = nread;
-					else if (flags & PTRDIFF)
+					}
+					else if ((flags & PTRDIFF) != 0) {
 						*va_arg(ap, ptrdiff_t *) = nread;
-					else
+					}
+					else {
 						*va_arg(ap, int *) = nread;
+					}
 					continue;
 			}
 
 			break;
 		}
-		if (c == '%')
+		if (c == '%') {
 			continue;
+		}
 
-		if (*inr <= 0)
+		if (*inr <= 0) {
 			return (nconversions != 0 ? nassigned : -1);
+		}
 
 		if ((flags & NOSKIP) == 0) {
-			while (isspace(*inp)) {
+			while (isspace(*inp) != 0) {
 				nread++;
-				if (--(*inr) > 0)
+				if (--(*inr) > 0) {
 					inp++;
-				else
+				}
+				else {
 					return (nconversions != 0 ? nassigned : -1);
+				}
 			}
 		}
 
@@ -328,9 +348,10 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 		 */
 		switch (c) {
 			case CT_CHAR:
-				if (width == 0)
+				if (width == 0) {
 					width = 1;
-				if (flags & SUPPRESS) {
+				}
+				if ((flags & SUPPRESS) != 0) {
 					size_t sum = 0;
 					for (;;) {
 						n = *inr;
@@ -338,8 +359,9 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 							sum += n;
 							width -= n;
 							inp += n;
-							if (sum == 0)
+							if (sum == 0) {
 								return (nconversions != 0 ? nassigned : -1);
+							}
 							break;
 						}
 						else {
@@ -362,41 +384,48 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				break;
 
 			case CT_CCL:
-				if (width == 0)
+				if (width == 0) {
 					width = (size_t)~0; /* `infinity' */
-				if (flags & SUPPRESS) {
+				}
+				if ((flags & SUPPRESS) != 0) {
 					n = 0;
-					while (ccltab[(unsigned char)*inp]) {
+					while (ccltab[(unsigned char)*inp] != 0) {
 						n++;
 						(*inr)--;
 						inp++;
-						if (--width == 0)
+						if (--width == 0) {
 							break;
+						}
 						if (*inr <= 0) {
-							if (n == 0)
+							if (n == 0) {
 								return (nconversions != 0 ? nassigned : -1);
+							}
 							break;
 						}
 					}
-					if (n == 0)
+					if (n == 0) {
 						return nassigned;
+					}
 				}
 				else {
 					p0 = p = va_arg(ap, char *);
-					while (ccltab[(unsigned char)*inp]) {
+					while (ccltab[(unsigned char)*inp] != 0) {
 						(*inr)--;
 						*p++ = *inp++;
-						if (--width == 0)
+						if (--width == 0) {
 							break;
+						}
 						if (*inr <= 0) {
-							if (p == p0)
+							if (p == p0) {
 								return (nconversions != 0 ? nassigned : -1);
+							}
 							break;
 						}
 					}
 					n = p - p0;
-					if (n == 0)
+					if (n == 0) {
 						return nassigned;
+					}
 					*p = 0;
 					nassigned++;
 				}
@@ -405,28 +434,33 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				break;
 
 			case CT_STRING:
-				if (width == 0)
+				if (width == 0) {
 					width = (size_t)~0;
-				if (flags & SUPPRESS) {
-					while (!isspace(*inp)) {
+				}
+				if ((flags & SUPPRESS) != 0) {
+					while (isspace(*inp) == 0) {
 						nread++;
 						(*inr)--;
 						inp++;
-						if (--width == 0)
+						if (--width == 0) {
 							break;
-						if (*inr <= 0)
+						}
+						if (*inr <= 0) {
 							break;
+						}
 					}
 				}
 				else {
 					p0 = p = va_arg(ap, char *);
-					while (!isspace(*inp)) {
+					while (isspace(*inp) == 0) {
 						(*inr)--;
 						*p++ = *inp++;
-						if (--width == 0)
+						if (--width == 0) {
 							break;
-						if (*inr <= 0)
+						}
+						if (*inr <= 0) {
 							break;
+						}
 					}
 					*p = 0;
 					nread += p - p0;
@@ -446,12 +480,14 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					break;
 				}
 
-				if (--width > sizeof(buf) - 2)
+				if (--width > (sizeof(buf) - 2)) {
 					width = sizeof(buf) - 2;
+				}
 				width++;
 
-				if (flags & SUPPRESS)
+				if ((flags & SUPPRESS) != 0) {
 					width = ~0;
+				}
 
 				flags |= SIGNOK | NDIGITS | NZDIGITS;
 				for (p = buf; width; width--) {
@@ -463,10 +499,12 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 								base = 8;
 								flags |= PFXOK;
 							}
-							if (flags & NZDIGITS)
+							if ((flags & NZDIGITS) != 0) {
 								flags &= ~(SIGNOK | NZDIGITS | NDIGITS);
-							else
+							}
+							else {
 								flags &= ~(SIGNOK | PFXOK | NDIGITS);
+							}
 							ok = 1;
 							break;
 
@@ -485,8 +523,9 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 						case '8':
 						case '9':
 							base = basefix[base];
-							if (base <= 8)
+							if (base <= 8) {
 								break; /* not legal here */
+							}
 							flags &= ~(SIGNOK | PFXOK | NDIGITS);
 							ok = 1;
 							break;
@@ -503,15 +542,16 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 						case 'd':
 						case 'e':
 						case 'f':
-							if (base <= 10)
+							if (base <= 10) {
 								break;
+							}
 							flags &= ~(SIGNOK | PFXOK | NDIGITS);
 							ok = 1;
 							break;
 
 						case '+':
 						case '-':
-							if (flags & SIGNOK) {
+							if ((flags & SIGNOK) != 0) {
 								flags &= ~SIGNOK;
 								ok = 1;
 							}
@@ -519,7 +559,7 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 
 						case 'x':
 						case 'X':
-							if (flags & PFXOK && p == buf + 1) {
+							if (((flags & PFXOK) != 0) && (p == buf + 1)) {
 								base = 16; /* if %i */
 								flags &= ~PFXOK;
 								ok = 1;
@@ -529,18 +569,22 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					if (!ok)
 						break;
 
-					if ((flags & SUPPRESS) == 0)
+					if ((flags & SUPPRESS) == 0) {
 						*p++ = c;
-					if (--(*inr) > 0)
+					}
+					if (--(*inr) > 0) {
 						inp++;
-					else
+					}
+					else {
 						break;
+					}
 				}
-				if (flags & NDIGITS)
+				if ((flags & NDIGITS) != 0) {
 					return (nconversions != 0 ? nassigned : -1);
+				}
 
 				c = ((unsigned char *)p)[-1];
-				if (c == 'x' || c == 'X') {
+				if ((c == 'x') || (c == 'X')) {
 					--p;
 					inp--;
 					(*inr)++;
@@ -550,23 +594,30 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 					uint64_t res;
 
 					*p = 0;
-					if ((flags & UNSIGNED) == 0)
+					if ((flags & UNSIGNED) == 0) {
 						res = strtoll(buf, (char **)NULL, base);
-					else
+					}
+					else {
 						res = strtoull(buf, (char **)NULL, base);
-					if (flags & POINTER)
-						*va_arg(ap, void **) =
-							(void *)(unsigned long)res;
-					else if (flags & SHORTSHORT)
+					}
+					if ((flags & POINTER) != 0) {
+						*va_arg(ap, void **) = (void *)(unsigned long)res;
+					}
+					else if ((flags & SHORTSHORT) != 0) {
 						*va_arg(ap, char *) = res;
-					else if (flags & SHORT)
+					}
+					else if ((flags & SHORT) != 0) {
 						*va_arg(ap, short *) = res;
-					else if (flags & LONG)
+					}
+					else if ((flags & LONG) != 0) {
 						*va_arg(ap, long *) = res;
-					else if (flags & LONGLONG)
+					}
+					else if ((flags & LONGLONG) != 0) {
 						*va_arg(ap, long long *) = res;
-					else if (flags & PTRDIFF)
+					}
+					else if ((flags & PTRDIFF) != 0) {
 						*va_arg(ap, ptrdiff_t *) = res;
+					}
 					else {
 						*va_arg(ap, int *) = res;
 					}
@@ -578,11 +629,11 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				break;
 
 			case CT_FLOAT:
-				if (width == 0 || width > sizeof(buf) - 1) {
+				if ((width == 0) || (width > sizeof(buf) - 1)) {
 					width = sizeof(buf) - 1;
 				}
 
-				if (strtold(inp, &p) == 0 && (inp == p || errno == ERANGE)) {
+				if ((strtold(inp, &p) == 0) && ((inp == p) || (errno == ERANGE))) {
 					return (nconversions != 0 ? nassigned : -1);
 				}
 

--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -364,35 +364,23 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				if (width == 0) {
 					width = 1;
 				}
-				if ((flags & SUPPRESS) != 0) {
-					size_t sum = 0;
-					for (;;) {
-						n = *inr;
-						if (n < (int)width) {
-							sum += n;
-							width -= n;
-							inp += n;
-							if (sum == 0) {
-								return (nconversions != 0 ? nassigned : -1);
-							}
-							break;
-						}
-						else {
-							sum += width;
-							*inr -= width;
-							inp += width;
-							break;
-						}
-					}
-					nread += sum;
+
+				if (*inr <= 0) {
+					return (nconversions != 0 ? nassigned : -1);
 				}
-				else {
+
+				if (width > *inr) {
+					width = *inr;
+				}
+
+				if ((flags & SUPPRESS) == 0) {
 					memcpy(va_arg(ap, char *), inp, width);
-					*inr -= width;
-					inp += width;
-					nread += width;
 					nassigned++;
 				}
+
+				*inr -= width;
+				inp += width;
+				nread += width;
 				nconversions++;
 				break;
 

--- a/stdio/scanf.c
+++ b/stdio/scanf.c
@@ -630,6 +630,7 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				break;
 
 			case CT_FLOAT: {
+#ifndef IO_NO_FLOAT
 				union {
 					float f;
 					double d;
@@ -686,6 +687,9 @@ static int scanf_parse(char *ccltab, const char *inp, int *inr, char const *fmt0
 				}
 
 				break;
+#else
+				return (nconversions != 0 ? nassigned : -1);
+#endif
 			}
 
 			default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
https://github.com/phoenix-rtos/libphoenix/pull/437
https://github.com/phoenix-rtos/libphoenix/pull/370 - scanf part
https://github.com/phoenix-rtos/libphoenix/pull/357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
