### PR TITLE
time: handle CLOCK_THREAD_CPUTIME_ID

### DIFF
--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -83,7 +83,7 @@ static inline int beginthread(void (*start)(void *), unsigned int priority, void
 }
 
 
-extern int threadsinfo(int n, threadinfo_t *info);
+extern int threadsinfo(int *tid, unsigned int flags, int n, threadinfo_t *info);
 
 
 extern int priority(int priority);

--- a/include/time.h
+++ b/include/time.h
@@ -26,9 +26,10 @@
 #define CLOCKS_PER_SEC 1000000
 
 
-#define CLOCK_MONOTONIC     0
-#define CLOCK_MONOTONIC_RAW 1
-#define CLOCK_REALTIME      2
+#define CLOCK_MONOTONIC         (0U)
+#define CLOCK_MONOTONIC_RAW     (1U)
+#define CLOCK_REALTIME          (2U)
+#define CLOCK_THREAD_CPUTIME_ID (3U)
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description
This pull request adds support for POSIX specified `CLOCK_THREAD_CPUTIME_ID` flag in `clock_gettime`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment
- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/libphoenix/pull/454
- https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/251
- https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/720
- [x] I will merge this PR by myself when appropriate.
