### PR TITLE
posix: implement POSIX semaphore interfaces

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -5,12 +5,10 @@
  *
  * assert.h
  *
- * Copyright 2017 Phoenix Systems
- * Author: Pawel Pisarczyk
+ * Copyright 2017, 2026 Phoenix Systems
+ * Author: Pawel Pisarczyk, Michal Lach
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _LIBPHOENIX_ASSERT_H_
@@ -23,6 +21,16 @@
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/*
+ * We want to be able to include our headers in C++ source and it uses a different
+ * keyword for static assertions, the same goes for C from C23 onwards
+ */
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
+#define STATIC_ASSERT static_assert
+#else
+#define STATIC_ASSERT _Static_assert
 #endif
 
 

--- a/include/limits.h
+++ b/include/limits.h
@@ -5,12 +5,10 @@
  *
  * limits.h
  *
- * Copyright 2019 Phoenix Systems
- * Author: Andrzej Glowinski
+ * Copyright 2019, 2026 Phoenix Systems
+ * Author: Andrzej Glowinski, Michal Lach
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _LIMITS_H_
@@ -35,5 +33,8 @@
 #include <phoenix/limits.h>
 
 #include <posix/limits.h>
+
+#define SEM_VALUE_MAX INT_MAX
+#define SEM_NSEMS_MAX _POSIX_SEM_NSEMS_MAX
 
 #endif

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -6,7 +6,7 @@
  * POSIX implementation - semaphores
  *
  * Copyright 2026 Phoenix Systems
- * Author: Michał Lach
+ * Author: Michal Lach
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -1,0 +1,76 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * POSIX implementation - semaphores
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michał Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _LIBPHOENIX_SEMAPHORE_H_
+#define _LIBPHOENIX_SEMAPHORE_H_
+
+#include <time.h>
+#include <limits.h>
+#include <sys/threads.h>
+#include <sys/semaphore.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SEM_FAILED ((sem_t *)0)
+
+
+typedef struct _sem_t {
+	/* clang-format off */
+	enum { smNamed, smUnnamed } type;
+	/* clang-format on */
+
+	union {
+		semaphore_t unnamed;
+		oid_t named;
+	};
+} sem_t;
+
+
+extern int sem_wait(sem_t *sem);
+
+
+extern int sem_trywait(sem_t *sem);
+
+
+extern int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict abs_timeout);
+
+
+extern int sem_getvalue(sem_t *restrict sem, int *restrict value);
+
+
+extern int sem_post(sem_t *sem);
+
+
+extern int sem_close(sem_t *sem);
+
+
+extern sem_t *sem_open(const char *name, int oflag, ... /* mode_t mode, unsigned int value */);
+
+
+extern int sem_unlink(const char *name);
+
+
+extern int sem_destroy(sem_t *sem);
+
+
+extern int sem_init(sem_t *sem, int pshared, unsigned int value);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _LIBPHOENIX_SEMAPHORE_H_ */

--- a/include/sys/semaphore.h
+++ b/include/sys/semaphore.h
@@ -6,7 +6,7 @@
  * POSIX implementation - semaphores
  *
  * Copyright 2026 Phoenix Systems
- * Author: Michał Lach
+ * Author: Michal Lach
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,7 @@
 #ifndef _LIBPHOENIX_SYS_SEMAPHORE_H_
 #define _LIBPHOENIX_SYS_SEMAPHORE_H_
 
+#include <assert.h>
 #include <limits.h>
 #include <sys/ioctl.h>
 
@@ -26,6 +27,11 @@ extern "C" {
 
 STATIC_ASSERT(SEM_VALUE_MAX >= _POSIX_SEM_VALUE_MAX, "SEM_VALUE_MAX shall be greater or equal to _POSIX_SEM_VALUE_MAX");
 STATIC_ASSERT(SEM_NSEMS_MAX >= _POSIX_SEM_NSEMS_MAX, "SEM_NSEMS_MAX shall be greater or equal to _POSIX_SEM_NSEMS_MAX");
+
+/* not required by POSIX, but ensures that
+ * sem_getvalue() does not return an overflowed value.
+ */
+STATIC_ASSERT(SEM_VALUE_MAX <= INT_MAX, "SEM_VALUE_MAX shall be smaller or equal to INT_MAX");
 
 #define SEM_UP           _IO('s', 0x1)
 #define SEM_DOWN         _IO('s', 0x2)

--- a/include/sys/semaphore.h
+++ b/include/sys/semaphore.h
@@ -1,0 +1,40 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * POSIX implementation - semaphores
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michał Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _LIBPHOENIX_SYS_SEMAPHORE_H_
+#define _LIBPHOENIX_SYS_SEMAPHORE_H_
+
+#include <limits.h>
+#include <sys/ioctl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SEMAPHORE_PATH "/dev/posix/sem/"
+#define SEMCTL_PATH    "/dev/posix/semctl"
+
+STATIC_ASSERT(SEM_VALUE_MAX >= _POSIX_SEM_VALUE_MAX, "SEM_VALUE_MAX shall be greater or equal to _POSIX_SEM_VALUE_MAX");
+STATIC_ASSERT(SEM_NSEMS_MAX >= _POSIX_SEM_NSEMS_MAX, "SEM_NSEMS_MAX shall be greater or equal to _POSIX_SEM_NSEMS_MAX");
+
+#define SEM_UP           _IO('s', 0x1)
+#define SEM_DOWN         _IO('s', 0x2)
+#define SEM_DOWN_TRY     _IO('s', 0x3)
+#define SEM_DOWN_TIMEOUT _IOW('s', 0x4, time_t)
+#define SEM_GETVALUE     _IOR('s', 0x5, unsigned int)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _LIBPHOENIX_SYS_SEMAPHORE_H_ */

--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -5,8 +5,8 @@
  *
  * sys/threads
  *
- * Copyright 2017, 2018 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski
+ * Copyright 2017, 2018, 2026 Phoenix Systems
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Michal Lach
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,8 @@
 #ifndef _LIBPHOENIX_SYS_THREADS_H_
 #define _LIBPHOENIX_SYS_THREADS_H_
 
+#include <assert.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/rb.h>
 #include <stddef.h>

--- a/include/sys/threads.h
+++ b/include/sys/threads.h
@@ -8,9 +8,7 @@
  * Copyright 2017, 2018 Phoenix Systems
  * Author: Pawel Pisarczyk, Aleksander Kaminski
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef _LIBPHOENIX_SYS_THREADS_H_
@@ -113,10 +111,16 @@ extern int semaphoreCreate(semaphore_t *s, unsigned int v);
 extern int semaphoreDown(semaphore_t *s, time_t timeout);
 
 
+extern int semaphoreTryDown(semaphore_t *s);
+
+
 extern int semaphoreUp(semaphore_t *s);
 
 
 extern int semaphoreDone(semaphore_t *s);
+
+
+extern int semaphoreCount(semaphore_t *s);
 
 
 extern int phCondCreate(handle_t *h, const struct condAttr *attr);

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -8,9 +8,7 @@
  * Copyright 2017, 2018 Phoenix Systems
  * Author: Pawel Pisarczyk, Kamil Amanowicz, Aleksander Kaminski
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 
@@ -44,12 +42,14 @@ extern "C" {
 #define X_OK (1 << 0)
 
 
-#define _SC_OPEN_MAX   0
-#define _SC_IOV_MAX    1
-#define _SC_ATEXIT_MAX 2
-#define _SC_CLK_TCK    3
-#define _SC_PAGESIZE   4
-#define _SC_PAGE_SIZE  _SC_PAGESIZE /* spec. 1170 compatibility */
+#define _SC_OPEN_MAX      0
+#define _SC_IOV_MAX       1
+#define _SC_ATEXIT_MAX    2
+#define _SC_CLK_TCK       3
+#define _SC_PAGESIZE      4
+#define _SC_SEM_VALUE_MAX 5
+#define _SC_SEM_NSEMS_MAX 6
+#define _SC_PAGE_SIZE     _SC_PAGESIZE /* spec. 1170 compatibility */
 
 #define _POSIX_NO_TRUNC             1
 #define _POSIX_ASYNC_IO             -1 /* Async IO not implemented. */

--- a/posix/Makefile
+++ b/posix/Makefile
@@ -5,4 +5,4 @@
 # Author: Pawel Pisarczyk
 #
 
-OBJS += $(addprefix $(PREFIX_O)posix/, stubs.o utils.o idtree.o)
+OBJS += $(addprefix $(PREFIX_O)posix/, stubs.o utils.o idtree.o sem.o)

--- a/posix/sem.c
+++ b/posix/sem.c
@@ -1,0 +1,471 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * POSIX implementation - semaphores
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdbool.h>
+#include <fcntl.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <semaphore.h>
+#include <stdarg.h>
+#include <dirent.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/msg.h>
+#include <sys/types.h>
+#include <sys/minmax.h>
+#include <sys/semaphore.h>
+#include <phoenix/ioctl.h>
+
+#include "../common/util.h"
+
+
+static int sem_msgOpen(sem_t *sem)
+{
+	int ret = EOK;
+	msg_t msg = {
+		.type = mtOpen,
+		.oid = sem->named,
+	};
+
+	ret = msgSend(sem->named.port, &msg);
+	if (ret != EOK) {
+		return ret;
+	}
+
+	return msg.o.err;
+}
+
+
+static int sem_msgDown(sem_t *sem, bool try, time_t timeout)
+{
+	int ret = EOK;
+	ioctl_in_t *data;
+	msg_t msg = {
+		.type = mtDevCtl,
+		.oid = sem->named,
+	};
+
+	data = (ioctl_in_t *)&msg.i.raw;
+	if (try) {
+		data->request = SEM_DOWN_TRY;
+	}
+	else if (timeout > 0) {
+		data->request = SEM_DOWN_TIMEOUT;
+		memcpy(data->data, &timeout, sizeof(timeout));
+	}
+	else {
+		data->request = SEM_DOWN;
+	}
+
+	ret = msgSend(sem->named.port, &msg);
+	if (ret == EOK) {
+		ret = msg.o.err;
+	}
+
+	return ret;
+}
+
+
+static int sem_msgCreate(const char *name, int value, oid_t *oid)
+{
+	int ret = EOK;
+	oid_t semctl;
+	msg_t msg = { 0 };
+
+	ret = lookup(SEMCTL_PATH, NULL, &semctl);
+	if (ret != EOK) {
+		return ret;
+	}
+
+	msg.type = mtCreate;
+	msg.oid = semctl;
+	msg.i.create.type = value;
+	msg.i.create.mode = 0;
+	msg.i.data = name;
+	msg.i.size = strlen(name) + 1;
+
+	ret = msgSend(semctl.port, &msg);
+	if (ret == EOK) {
+		ret = msg.o.err;
+	}
+
+	if (oid != NULL) {
+		*oid = msg.o.create.oid;
+	}
+
+	return ret;
+}
+
+
+static int sem_lookup(const char *name, oid_t *sem)
+{
+	int ret = EOK;
+	DIR *dirp;
+	struct dirent *dent;
+	oid_t oid;
+	char *path;
+
+	dirp = opendir(SEMAPHORE_PATH);
+	if (dirp == NULL) {
+		/* posixsrv has not yet initialized the semaphore subsystem */
+		return -ENODEV;
+	}
+
+	path = malloc(PATH_MAX + 1);
+	if (path == NULL) {
+		return -ENOMEM;
+	}
+
+	if (*name == '/') {
+		name++;
+	}
+
+	memset(path, 0, PATH_MAX + 1);
+	for (;;) {
+		errno = 0;
+		dent = readdir(dirp);
+		if (dent == NULL) {
+			closedir(dirp);
+			ret = -ENOENT;
+			break;
+		}
+
+		if (strncmp(name, dent->d_name, NAME_MAX) == 0) {
+			snprintf(path, PATH_MAX, "%s%s", SEMAPHORE_PATH, dent->d_name);
+			ret = lookup(path, NULL, &oid);
+			if (ret != EOK) {
+				closedir(dirp);
+				break;
+			}
+
+			*sem = oid;
+			closedir(dirp);
+			ret = EOK;
+			break;
+		}
+	}
+
+	free(path);
+
+	return ret;
+}
+
+
+sem_t *sem_open(const char *name, int oflag, ...)
+{
+	va_list list;
+	int err = EOK;
+	mode_t mode = 0;
+	unsigned int value = 0;
+	sem_t *sem;
+
+	/* @FIXME(michal.lach): message sent to posixsrv should contain passed mode.
+	 * Semaphores are treated as devices, created with create_dev(), which,
+	 * in turn, does not allow to specify custom file mode and uses 0666 by
+	 * default.
+	 */
+	(void)mode;
+
+	if (name == NULL) {
+		errno = EINVAL;
+		return SEM_FAILED;
+	}
+
+	if (strlen(name) > NAME_MAX) {
+		errno = -ENAMETOOLONG;
+		return SEM_FAILED;
+	}
+
+	sem = malloc(sizeof(*sem));
+	if (sem == NULL) {
+		errno = ENOMEM;
+		return SEM_FAILED;
+	}
+
+	sem->type = smNamed;
+
+	if ((oflag & O_CREAT) != 0) {
+		va_start(list, oflag);
+		mode = va_arg(list, mode_t);
+		value = va_arg(list, unsigned int);
+		va_end(list);
+	}
+
+	if ((oflag & O_CREAT) != 0 && (oflag & O_EXCL) != 0) {
+		err = sem_msgCreate(name, value, &sem->named);
+	}
+	else {
+		err = sem_lookup(name, &sem->named);
+		if ((oflag & O_CREAT) != 0 && err < 0) {
+			err = sem_msgCreate(name, value, &sem->named);
+		}
+	}
+
+	if (err != EOK) {
+		SET_ERRNO(err);
+		free(sem);
+		return SEM_FAILED;
+	}
+
+	err = sem_msgOpen(sem);
+	if (err != EOK) {
+		SET_ERRNO(err);
+		free(sem);
+		return SEM_FAILED;
+	}
+
+	return sem;
+}
+
+
+int sem_wait(sem_t *sem)
+{
+	int ret = EOK;
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (sem->type == smNamed) {
+		ret = sem_msgDown(sem, false, 0);
+	}
+	else if (sem->type == smUnnamed) {
+		ret = semaphoreDown(&sem->unnamed, 0);
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_trywait(sem_t *sem)
+{
+	int ret = EOK;
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (sem->type == smNamed) {
+		ret = sem_msgDown(sem, true, 0);
+	}
+	else if (sem->type == smUnnamed) {
+		ret = semaphoreTryDown(&sem->unnamed);
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict abstime)
+{
+	int ret = EOK;
+	time_t timeout = 0, now = 0, offs = 0;
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (!__timespecValid(abstime)) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	gettime(&now, &offs);
+	now += offs;
+
+	timeout += abstime->tv_sec * 1000000 + abstime->tv_nsec / 1000;
+	timeout -= now;
+
+	if (timeout <= 0) {
+		ret = sem_trywait(sem);
+		if (ret != EOK) {
+			return SET_ERRNO(-ETIMEDOUT);
+		}
+
+		return SET_ERRNO(ret != EOK ? -ETIMEDOUT : ret);
+	}
+
+	if (sem->type == smNamed) {
+		ret = sem_msgDown(sem, false, timeout);
+	}
+	else if (sem->type == smUnnamed) {
+		ret = semaphoreDown(&sem->unnamed, timeout);
+		if (ret == -ETIME) {
+			ret = -ETIMEDOUT;
+		}
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_post(sem_t *sem)
+{
+	int ret = EOK;
+	msg_t msg = { 0 };
+	ioctl_in_t *data;
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (sem->type == smNamed) {
+		msg.type = mtDevCtl;
+		msg.oid = sem->named;
+		data = (ioctl_in_t *)msg.i.raw;
+		data->request = SEM_UP;
+		ret = msgSend(sem->named.port, &msg);
+		if (ret == EOK) {
+			ret = msg.o.err;
+		}
+	}
+	else if (sem->type == smUnnamed) {
+		ret = semaphoreUp(&sem->unnamed);
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_getvalue(sem_t *restrict sem, int *restrict value)
+{
+	int ret = EOK;
+	msg_t msg = { 0 };
+	int v;
+	ioctl_in_t *data;
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (sem->type == smNamed) {
+		msg.type = mtDevCtl;
+		msg.oid = sem->named;
+		data = (ioctl_in_t *)msg.i.raw;
+		data->request = SEM_GETVALUE;
+		ret = msgSend(sem->named.port, &msg);
+		if (ret == EOK) {
+			ret = msg.o.err;
+			memcpy(&v, msg.o.raw, sizeof(v));
+			if (value != NULL) {
+				*value = v;
+			}
+		}
+	}
+	else if (sem->type == smUnnamed) {
+		ret = semaphoreCount(&sem->unnamed);
+		if (ret > 0 && value != NULL) {
+			*value = ret;
+		}
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_close(sem_t *sem)
+{
+	int ret = EOK;
+	msg_t msg = { 0 };
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	if (sem->type == smNamed) {
+		msg.type = mtClose;
+		msg.oid = sem->named;
+		ret = msgSend(sem->named.port, &msg);
+		if (ret == EOK) {
+			free(sem);
+			ret = msg.o.err;
+		}
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_init(sem_t *sem, int pshared, unsigned int value)
+{
+	int ret = EOK;
+	sem_t new = { 0 };
+
+	if (pshared != 0) {
+		return SET_ERRNO(-ENOSYS);
+	}
+
+	if (sem == NULL) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	new.type = smUnnamed;
+	ret = semaphoreCreate(&new.unnamed, value);
+	if (ret != EOK) {
+		return SET_ERRNO(-ENOSPC);
+	}
+
+	*sem = new;
+
+	return SET_ERRNO(ret);
+}
+
+
+int sem_destroy(sem_t *sem)
+{
+	if (sem == NULL || sem->type != smUnnamed) {
+		return SET_ERRNO(-EINVAL);
+	}
+
+	return SET_ERRNO(semaphoreDone(&sem->unnamed));
+}
+
+
+int sem_unlink(const char *name)
+{
+	int ret = EOK;
+	oid_t oid;
+	msg_t msg = { 0 };
+
+	ret = sem_lookup(name, &oid);
+	if (ret != EOK) {
+		return SET_ERRNO(ret);
+	}
+
+	msg.type = mtDestroy;
+	msg.oid = oid;
+	ret = msgSend(oid.port, &msg);
+	if (ret == EOK) {
+		ret = msg.o.err;
+	}
+
+	return SET_ERRNO(ret);
+}

--- a/sys/semaphore.c
+++ b/sys/semaphore.c
@@ -5,7 +5,7 @@
  *
  * Copyright 2012, 2017, 2018, 2026 Phoenix Systems
  * Copyright 2006 Pawel Pisarczyk
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Michał Lach
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Michal Lach
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/sys/semaphore.c
+++ b/sys/semaphore.c
@@ -5,24 +5,50 @@
  *
  * Copyright 2012, 2017, 2018, 2026 Phoenix Systems
  * Copyright 2006 Pawel Pisarczyk
- * Author: Pawel Pisarczyk, Aleksander Kaminski
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Michał Lach
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stdbool.h>
+#include <assert.h>
 #include <sys/time.h>
 #include <errno.h>
 #include <sys/threads.h>
+#include <sys/semaphore.h>
 #include <time.h>
+
+
+int semaphoreCount(semaphore_t *s)
+{
+	int ret = 0;
+
+	if (s == NULL) {
+		return -EINVAL;
+	}
+
+	ret = mutexTry(s->mutex);
+	if (ret != EOK) {
+		ret = 0;
+	}
+	else {
+		ret = s->v;
+		assert(ret >= 0); /* s->v is unsigned, we don't want to overflow */
+		mutexUnlock(s->mutex);
+	}
+
+	return ret;
+}
 
 
 int semaphoreCreate(semaphore_t *s, unsigned int v)
 {
 	static const struct condAttr cAttr = { .clock = PH_CLOCK_MONOTONIC };
 	int err;
+
+	if (s == NULL || v > SEM_VALUE_MAX) {
+		return -EINVAL;
+	}
 
 	err = mutexCreate(&s->mutex);
 	if (err < 0) {
@@ -65,6 +91,31 @@ int semaphoreDown(semaphore_t *s, time_t timeout)
 	mutexUnlock(s->mutex);
 
 	return err;
+}
+
+
+int semaphoreTryDown(semaphore_t *s)
+{
+	int ret = EOK;
+
+	if (s != NULL) {
+		ret = mutexTry(s->mutex);
+		if (ret != EOK) {
+			return ret;
+		}
+		else if (s->v <= 0) {
+			ret = -EAGAIN;
+		}
+		else {
+			--s->v;
+		}
+	}
+	else {
+		ret = -EINVAL;
+	}
+
+	mutexUnlock(s->mutex);
+	return ret;
 }
 
 

--- a/unistd/conf.c
+++ b/unistd/conf.c
@@ -8,9 +8,7 @@
  * Copyright 2018 Phoenix Systems
  * Author: Michal Miroslaw
  *
- * This file is part of Phoenix-RTOS.
- *
- * %LICENSE%
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <errno.h>
@@ -35,6 +33,10 @@ long sysconf(int name)
 		case _SC_PAGESIZE:
 			/* _SC_PAGE_SIZE is synonym */
 			return _PAGE_SIZE;
+		case _SC_SEM_VALUE_MAX:
+			return SEM_VALUE_MAX;
+		case _SC_SEM_NSEMS_MAX:
+			return SEM_NSEMS_MAX;
 		default:
 			errno = EINVAL;
 			return -1;


### PR DESCRIPTION
TASK: RTOS-1407

## Description
This PR introduces implementation of POSIX standard semaphore interfaces.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [X] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/448
- [X] Tested by hand on: `ia32-generic-qemu`

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
 - https://github.com/phoenix-rtos/phoenix-rtos-posixsrv/pull/27
 - https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/251
- [X] I will merge this PR by myself when appropriate.
