### PR TITLE
termios: Add TIOCSHALFD for ioctl() for enabling half-duplex uart

### DIFF
--- a/include/termios.h
+++ b/include/termios.h
@@ -200,6 +200,8 @@ struct winsize {
 #define TIOCSWINSZ _IOW('t', 0x14, struct winsize)
 #define TIOCNOTTY  _IO('t', 0x22)
 #define TIOCGSID   _IOR('t', 0x29, pid_t)
+#define TIOCGHALFD _IOR('t', 0x80, int)
+#define TIOCSHALFD _IOV('t', 0x81, int)
 
 /* tcflush */
 enum { TCIFLUSH,


### PR DESCRIPTION
TASK: PP-428

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add TIOCSHALFD for ioctl() for enabling half-duplex uart

## Motivation and Context
Allows enabling half-duplex mode (for now supported in stm32n6 only).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
