### PR TITLE
regex: change old-style definitions

### DIFF
--- a/regex/.clang-format
+++ b/regex/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/regex/collate.c
+++ b/regex/collate.c
@@ -58,8 +58,7 @@ struct __collate_st_chain_pri __collate_chain_pri_table[TABLE_SIZE];
 void __collate_err(int ex, const char *f);
 
 int
-__collate_load_tables(encoding)
-	char *encoding;
+__collate_load_tables(char *encoding)
 {
 	char buf[PATH_MAX];
 	FILE *fp;
@@ -113,8 +112,7 @@ __collate_load_tables(encoding)
 }
 
 u_char *
-__collate_substitute(s)
-	const u_char *s;
+__collate_substitute(const u_char *s)
 {
 	int dest_len, len, nlen;
 	int delta = strlen((const char *) s);
@@ -143,9 +141,7 @@ __collate_substitute(s)
 }
 
 void
-__collate_lookup(t, len, prim, sec)
-	const u_char *t;
-	int *len, *prim, *sec;
+__collate_lookup(const u_char *t, int *len, int *prim, int *sec)
 {
 	struct __collate_st_chain_pri *p2;
 
@@ -165,8 +161,7 @@ __collate_lookup(t, len, prim, sec)
 }
 
 u_char *
-__collate_strdup(s)
-	u_char *s;
+__collate_strdup(u_char *s)
 {
 	u_char *t = (u_char *) strdup((const char *) s);
 

--- a/regex/collate.h
+++ b/regex/collate.h
@@ -54,11 +54,11 @@ extern struct __collate_st_char_pri __collate_char_pri_table[UCHAR_MAX + 1];
 extern struct __collate_st_chain_pri __collate_chain_pri_table[TABLE_SIZE];
 
 __BEGIN_DECLS
-u_char	*__collate_strdup(u_char *);
-u_char	*__collate_substitute(const u_char *);
-int	__collate_load_tables(char *);
-void	__collate_lookup(const u_char *, int *, int *, int *);
-int	__collate_range_cmp(int, int);
+u_char	*__collate_strdup(u_char *s);
+u_char	*__collate_substitute(const u_char *s);
+int	__collate_load_tables(char *encoding);
+void	__collate_lookup(const u_char *t, int *len, int *prim, int *sec);
+int	__collate_range_cmp(int c1, int c2);
 #ifdef COLLATE_DEBUG
 void	__collate_print_tables(void);
 #endif

--- a/regex/collcmp.c
+++ b/regex/collcmp.c
@@ -40,8 +40,7 @@
  * "[a-z]"-type ranges with national characters.
  */
 
-int __collate_range_cmp (c1, c2)
-	int c1, c2;
+int __collate_range_cmp(int c1, int c2)
 {
 	static char s1[2], s2[2];
 	int ret;

--- a/regex/engine.c
+++ b/regex/engine.c
@@ -135,12 +135,8 @@ static char *pchar(int ch);
  ==	size_t nmatch, regmatch_t pmatch[], int eflags);
  */
 static int			/* 0 success, REG_NOMATCH failure */
-matcher(g, string, nmatch, pmatch, eflags)
-struct re_guts *g;
-char *string;
-size_t nmatch;
-regmatch_t pmatch[];
-int eflags;
+matcher(struct re_guts *g, char *string, size_t nmatch, regmatch_t pmatch[],
+		int eflags)
 {
 	char *endp;
 	int i;
@@ -346,12 +342,7 @@ int eflags;
  ==	char *stop, sopno startst, sopno stopst);
  */
 static char *			/* == stop (success) always */
-dissect(m, start, stop, startst, stopst)
-struct match *m;
-char *start;
-char *stop;
-sopno startst;
-sopno stopst;
+dissect(struct match *m, char *start, char *stop, sopno startst, sopno stopst)
 {
 	int i;
 	sopno ss;		/* start sop of current subRE */
@@ -539,13 +530,12 @@ sopno stopst;
  ==	char *stop, sopno startst, sopno stopst, sopno lev);
  */
 static char *			/* == stop (success) or NULL (failure) */
-backref(m, start, stop, startst, stopst, lev)
-struct match *m;
-char *start;
-char *stop;
-sopno startst;
-sopno stopst;
-sopno lev;			/* PLUS nesting level */
+backref(struct match *m,
+	char *start,
+	char *stop,
+	sopno startst,
+	sopno stopst,
+	sopno lev /* PLUS nesting level */)
 {
 	int i;
 	sopno ss;		/* start sop of current subRE */
@@ -744,12 +734,7 @@ sopno lev;			/* PLUS nesting level */
  ==	char *stop, sopno startst, sopno stopst);
  */
 static char *			/* where tentative match ended, or NULL */
-fast(m, start, stop, startst, stopst)
-struct match *m;
-char *start;
-char *stop;
-sopno startst;
-sopno stopst;
+fast(struct match *m, char *start, char *stop, sopno startst, sopno stopst)
 {
 	states st = m->st;
 	states fresh = m->fresh;
@@ -835,12 +820,7 @@ sopno stopst;
  ==	char *stop, sopno startst, sopno stopst);
  */
 static char *			/* where it ended */
-slow(m, start, stop, startst, stopst)
-struct match *m;
-char *start;
-char *stop;
-sopno startst;
-sopno stopst;
+slow(struct match *m, char *start, char *stop, sopno startst, sopno stopst)
 {
 	states st = m->st;
 	states empty = m->empty;
@@ -931,13 +911,12 @@ sopno stopst;
  == #define	NNONCHAR	(CODEMAX-CHAR_MAX)
  */
 static states
-step(g, start, stop, bef, ch, aft)
-struct re_guts *g;
-sopno start;			/* start state within strip */
-sopno stop;			/* state after stop state within strip */
-states bef;			/* states reachable before */
-int ch;				/* character or NONCHAR code */
-states aft;			/* states already known reachable after */
+step(struct re_guts *g,
+     sopno start, /* start state within strip */
+     sopno stop, /* state after stop state within strip */
+     states bef, /* states reachable before */
+     int ch, /* character or NONCHAR code */
+     states aft /* states already known reachable after */)
 {
 	cset *cs;
 	sop s;
@@ -1053,12 +1032,7 @@ states aft;			/* states already known reachable after */
  == #endif
  */
 static void
-print(m, caption, st, ch, d)
-struct match *m;
-char *caption;
-states st;
-int ch;
-FILE *d;
+print(struct match *m, char *caption, states st, int ch, FILE *d)
 {
 	struct re_guts *g = m->g;
 	int i;
@@ -1086,13 +1060,8 @@ FILE *d;
  == #endif
  */
 static void
-at(m, title, start, stop, startst, stopst)
-struct match *m;
-char *title;
-char *start;
-char *stop;
-sopno startst;
-sopno stopst;
+at(struct match *m, char *title, char *start, char *stop, sopno startst,
+		sopno stopst)
 {
 	if (!(m->eflags&REG_TRACE))
 		return;
@@ -1116,8 +1085,7 @@ sopno stopst;
  * the non-debug compilation anyway, so it doesn't matter much.
  */
 static char *			/* -> representation */
-pchar(ch)
-int ch;
+pchar(int ch)
 {
 	static char pbuf[10];
 

--- a/regex/fnmatch.c
+++ b/regex/fnmatch.c
@@ -55,12 +55,10 @@ static char sccsid[] = "@(#)fnmatch.c	8.2 (Berkeley) 4/16/94";
 #define RANGE_NOMATCH   0
 #define RANGE_ERROR     (-1)
 
-static int rangematch(const char *, char, int, char **);
+static int rangematch(const char *pattern, char test, int flags, char **newp);
 
 int
-fnmatch(pattern, string, flags)
-	const char *pattern, *string;
-	int flags;
+fnmatch(const char *pattern, const char *string, int flags)
 {
 	const char *stringstart;
 	char *newp;
@@ -163,11 +161,7 @@ fnmatch(pattern, string, flags)
 }
 
 static int
-rangematch(pattern, test, flags, newp)
-	const char *pattern;
-	char test;
-	int flags;
-	char **newp;
+rangematch(const char *pattern, char test, int flags, char **newp)
 {
 	int negate, ok;
 	char c, c2;

--- a/regex/glob.c
+++ b/regex/glob.c
@@ -133,34 +133,34 @@ typedef char Char;
 #define	ismeta(c)	(((c)&M_QUOTE) != 0)
 
 
-static int	 compare(const void *, const void *);
-static int	 g_Ctoc(const Char *, char *, u_int);
-static int	 g_lstat(Char *, struct stat *, glob_t *);
-static DIR	*g_opendir(Char *, glob_t *);
-static Char	*g_strchr(Char *, int);
-#ifdef notdef
+static int	 compare(const void *p, const void *q);
+static int	 g_Ctoc(const Char *str, char *buf, u_int len);
+static int	 g_lstat(Char *fn, struct stat *sb, glob_t *pglob);
+static DIR	*g_opendir(Char *str, glob_t *pglob);
+static Char	*g_strchr(Char *str, int ch);
+#ifdef NOTDEF
 static Char	*g_strcat(Char *, const Char *);
 #endif
-static int	 g_stat(Char *, struct stat *, glob_t *);
-static int	 glob0(const Char *, glob_t *, int *);
-static int	 glob1(Char *, glob_t *, int *);
-static int	 glob2(Char *, Char *, Char *, Char *, glob_t *, int *);
-static int	 glob3(Char *, Char *, Char *, Char *, Char *, glob_t *, int *);
-static int	 globextend(const Char *, glob_t *, int *);
-static const Char *
-		 globtilde(const Char *, Char *, size_t, glob_t *);
-static int	 globexp1(const Char *, glob_t *, int *);
-static int	 globexp2(const Char *, const Char *, glob_t *, int *, int *);
-static int	 match(Char *, Char *, Char *);
+static int	 g_stat(Char *fn, struct stat *sb, glob_t *pglob);
+static int	 glob0(const Char *pattern, glob_t *pglob, int *limit);
+static int	 glob1(Char *pattern, glob_t *pglob, int *limit);
+static int	 glob2(Char *pathbuf, Char *pathend, Char *pathend_last,
+		Char *pattern, glob_t *pglob, int *limit);
+static int	 glob3(Char *pathbuf, Char *pathend, Char *pathend_last,
+		Char *pattern, Char *restpattern, glob_t *pglob, int *limit);
+static int	 globextend(const Char *path, glob_t *pglob, int *limit);
+static const Char * globtilde(const Char *pattern, Char *patbuf,
+		size_t patbuf_len, glob_t *pglob);
+static int	 globexp1(const Char *pattern, glob_t *pglob, int *limit);
+static int	 globexp2(const Char *ptr, const Char *pattern, glob_t *pglob, int *rv, int *limit);
+static int	 match(Char *name, Char *pat, Char *patend);
 #ifdef DEBUG
-static void	 qprintf(const char *, Char *);
+static void	 qprintf(const char *str, Char *s);
 #endif
 
 int
-glob(pattern, flags, errfunc, pglob)
-	const char *__restrict pattern;
-	int flags, (*errfunc)(const char *, int);
-	glob_t *__restrict pglob;
+glob(const char *__restrict pattern, int flags,
+	int (*errfunc)(const char *, int), glob_t *__restrict pglob)
 {
 	const u_char *patnext;
 	int c, limit;
@@ -215,10 +215,7 @@ glob(pattern, flags, errfunc, pglob)
  * characters
  */
 static int
-globexp1(pattern, pglob, limit)
-	const Char *pattern;
-	glob_t *pglob;
-	int *limit;
+globexp1(const Char *pattern, glob_t *pglob, int *limit)
 {
 	const Char* ptr = pattern;
 	int rv;
@@ -241,10 +238,7 @@ globexp1(pattern, pglob, limit)
  * If it fails then it tries to glob the rest of the pattern and returns.
  */
 static int
-globexp2(ptr, pattern, pglob, rv, limit)
-	const Char *ptr, *pattern;
-	glob_t *pglob;
-	int *rv, *limit;
+globexp2(const Char *ptr, const Char *pattern, glob_t *pglob, int *rv, int *limit)
 {
 	int     i;
 	Char   *lm, *ls;
@@ -348,11 +342,7 @@ globexp2(ptr, pattern, pglob, rv, limit)
  * expand tilde from the passwd file.
  */
 static const Char *
-globtilde(pattern, patbuf, patbuf_len, pglob)
-	const Char *pattern;
-	Char *patbuf;
-	size_t patbuf_len;
-	glob_t *pglob;
+globtilde(const Char *pattern, Char *patbuf, size_t patbuf_len, glob_t *pglob)
 {
 	struct passwd *pwd;
 	char *h;
@@ -428,10 +418,7 @@ globtilde(pattern, patbuf, patbuf_len, pglob)
  * to find no matches.
  */
 static int
-glob0(pattern, pglob, limit)
-	const Char *pattern;
-	glob_t *pglob;
-	int *limit;
+glob0(const Char *pattern, glob_t *pglob, int *limit)
 {
 	const Char *qpatnext;
 	int c, err, oldpathc;
@@ -514,17 +501,13 @@ glob0(pattern, pglob, limit)
 }
 
 static int
-compare(p, q)
-	const void *p, *q;
+compare(const void *p, const void *q)
 {
 	return(strcmp(*(char **)p, *(char **)q));
 }
 
 static int
-glob1(pattern, pglob, limit)
-	Char *pattern;
-	glob_t *pglob;
-	int *limit;
+glob1(Char *pattern, glob_t *pglob, int *limit)
 {
 	Char pathbuf[MAXPATHLEN];
 
@@ -541,10 +524,7 @@ glob1(pattern, pglob, limit)
  * meta characters.
  */
 static int
-glob2(pathbuf, pathend, pathend_last, pattern, pglob, limit)
-	Char *pathbuf, *pathend, *pathend_last, *pattern;
-	glob_t *pglob;
-	int *limit;
+glob2(Char *pathbuf, Char *pathend, Char *pathend_last, Char *pattern, glob_t *pglob, int *limit)
 {
 	struct stat sb;
 	Char *p, *q;
@@ -601,10 +581,8 @@ glob2(pathbuf, pathend, pathend_last, pattern, pglob, limit)
 }
 
 static int
-glob3(pathbuf, pathend, pathend_last, pattern, restpattern, pglob, limit)
-	Char *pathbuf, *pathend, *pathend_last, *pattern, *restpattern;
-	glob_t *pglob;
-	int *limit;
+glob3(Char *pathbuf, Char *pathend, Char *pathend_last, Char *pattern,
+		Char *restpattern, glob_t *pglob, int *limit)
 {
 	struct dirent *dp;
 	DIR *dirp;
@@ -687,10 +665,7 @@ glob3(pathbuf, pathend, pathend_last, pattern, restpattern, pglob, limit)
  *	gl_pathv points to (gl_offs + gl_pathc + 1) items.
  */
 static int
-globextend(path, pglob, limit)
-	const Char *path;
-	glob_t *pglob;
-	int *limit;
+globextend(const Char *path, glob_t *pglob, int *limit)
 {
 	char **pathv;
 	int i;
@@ -742,8 +717,7 @@ globextend(path, pglob, limit)
  * pattern causes a recursion level.
  */
 static int
-match(name, pat, patend)
-	Char *name, *pat, *patend;
+match(Char *name, Char *pat, Char *patend)
 {
 	int ok, negate_range;
 	Char c, k;
@@ -794,8 +768,7 @@ match(name, pat, patend)
 
 /* Free allocated data belonging to a glob_t structure. */
 void
-globfree(pglob)
-	glob_t *pglob;
+globfree(glob_t *pglob)
 {
 	int i;
 	char **pp;
@@ -811,9 +784,7 @@ globfree(pglob)
 }
 
 static DIR *
-g_opendir(str, pglob)
-	Char *str;
-	glob_t *pglob;
+g_opendir(Char *str, glob_t *pglob)
 {
 	char buf[MAXPATHLEN];
 
@@ -831,10 +802,7 @@ g_opendir(str, pglob)
 }
 
 static int
-g_lstat(fn, sb, pglob)
-	Char *fn;
-	struct stat *sb;
-	glob_t *pglob;
+g_lstat(Char *fn, struct stat *sb, glob_t *pglob)
 {
 	char buf[MAXPATHLEN];
 
@@ -848,10 +816,7 @@ g_lstat(fn, sb, pglob)
 }
 
 static int
-g_stat(fn, sb, pglob)
-	Char *fn;
-	struct stat *sb;
-	glob_t *pglob;
+g_stat(Char *fn, struct stat *sb, glob_t *pglob)
 {
 	char buf[MAXPATHLEN];
 
@@ -865,9 +830,7 @@ g_stat(fn, sb, pglob)
 }
 
 static Char *
-g_strchr(str, ch)
-	Char *str;
-	int ch;
+g_strchr(Char *str, int ch)
 {
 	do {
 		if (*str == ch)
@@ -877,10 +840,7 @@ g_strchr(str, ch)
 }
 
 static int
-g_Ctoc(str, buf, len)
-	const Char *str;
-	char *buf;
-	u_int len;
+g_Ctoc(const Char *str, char *buf, u_int len)
 {
 
 	while (len--) {
@@ -892,9 +852,7 @@ g_Ctoc(str, buf, len)
 
 #ifdef DEBUG
 static void
-qprintf(str, s)
-	const char *str;
-	Char *s;
+qprintf(const char *str, Char *s)
 {
 	Char *p;
 

--- a/regex/regcomp.c
+++ b/regex/regcomp.c
@@ -188,10 +188,7 @@ static int never = 0;		/* for use in asserts; shuts lint up */
  = #define	REG_DUMP	0200
  */
 int				/* 0 success, otherwise REG_something */
-regcomp(preg, pattern, cflags)
-regex_t *__restrict preg;
-const char *__restrict pattern;
-int cflags;
+regcomp(regex_t *__restrict preg, const char *__restrict pattern, int cflags)
 {
 	struct parse pa;
 	struct re_guts *g;
@@ -306,9 +303,8 @@ int cflags;
  == static void p_ere(struct parse *p, int stop);
  */
 static void
-p_ere(p, stop)
-struct parse *p;
-int stop;			/* character this ERE should end at */
+p_ere(struct parse *p,
+      int stop /* character this ERE should end at */)
 {
 	char c;
 	sopno prevback = 0;
@@ -352,8 +348,7 @@ int stop;			/* character this ERE should end at */
  == static void p_ere_exp(struct parse *p);
  */
 static void
-p_ere_exp(p)
-struct parse *p;
+p_ere_exp(struct parse *p)
 {
 	char c;
 	sopno pos;
@@ -501,8 +496,7 @@ struct parse *p;
  == static void p_str(struct parse *p);
  */
 static void
-p_str(p)
-struct parse *p;
+p_str(struct parse *p)
 {
 	(void)REQUIRE(MORE(), REG_EMPTY);
 	while (MORE())
@@ -522,10 +516,9 @@ struct parse *p;
  * The amount of lookahead needed to avoid this kludge is excessive.
  */
 static void
-p_bre(p, end1, end2)
-struct parse *p;
-int end1;			/* first terminating character */
-int end2;			/* second terminating character */
+p_bre(struct parse *p,
+      int end1, /* first terminating character */
+      int end2 /* second terminating character */)
 {
 	sopno start = HERE();
 	int first = 1;			/* first subexpression? */
@@ -555,9 +548,8 @@ int end2;			/* second terminating character */
  == static int p_simp_re(struct parse *p, int starordinary);
  */
 static int			/* was the simple RE an unbackslashed $? */
-p_simp_re(p, starordinary)
-struct parse *p;
-int starordinary;		/* is a leading * an ordinary character? */
+p_simp_re(struct parse *p,
+	  int starordinary /* is leading * an ordinary character? */)
 {
 	int c;
 	int count;
@@ -673,8 +665,7 @@ int starordinary;		/* is a leading * an ordinary character? */
  == static int p_count(struct parse *p);
  */
 static int			/* the value */
-p_count(p)
-struct parse *p;
+p_count(struct parse *p)
 {
 	int count = 0;
 	int ndigits = 0;
@@ -696,8 +687,7 @@ struct parse *p;
  * no set operations are done.
  */
 static void
-p_bracket(p)
-struct parse *p;
+p_bracket(struct parse *p)
 {
 	cset *cs = allocset(p);
 	int invert = 0;
@@ -770,9 +760,7 @@ struct parse *p;
  == static void p_b_term(struct parse *p, cset *cs);
  */
 static void
-p_b_term(p, cs)
-struct parse *p;
-cset *cs;
+p_b_term(struct parse *p, cset *cs)
 {
 	char c;
 	char start, finish;
@@ -849,9 +837,7 @@ cset *cs;
  == static void p_b_cclass(struct parse *p, cset *cs);
  */
 static void
-p_b_cclass(p, cs)
-struct parse *p;
-cset *cs;
+p_b_cclass(struct parse *p, cset *cs)
 {
 	int c;
 	char *sp = p->next;
@@ -945,9 +931,7 @@ cset *cs;
  * This implementation is incomplete. xxx
  */
 static void
-p_b_eclass(p, cs)
-struct parse *p;
-cset *cs;
+p_b_eclass(struct parse *p, cset *cs)
 {
 	char c;
 
@@ -960,8 +944,7 @@ cset *cs;
  == static char p_b_symbol(struct parse *p);
  */
 static char			/* value of symbol */
-p_b_symbol(p)
-struct parse *p;
+p_b_symbol(struct parse *p)
 {
 	char value;
 
@@ -980,9 +963,7 @@ struct parse *p;
  == static char p_b_coll_elem(struct parse *p, int endc);
  */
 static char			/* value of collating element */
-p_b_coll_elem(p, endc)
-struct parse *p;
-int endc;			/* name ended by endc,']' */
+p_b_coll_elem(struct parse *p, int endc /* name ended by endc,']' */)
 {
 	char *sp = p->next;
 	struct cname *cp;
@@ -1009,8 +990,7 @@ int endc;			/* name ended by endc,']' */
  == static char othercase(int ch);
  */
 static char			/* if no counterpart, return ch */
-othercase(ch)
-int ch;
+othercase(int ch)
 {
 	ch = (uch)ch;
 	assert(isalpha(ch));
@@ -1029,9 +1009,7 @@ int ch;
  * Boy, is this implementation ever a kludge...
  */
 static void
-bothcases(p, ch)
-struct parse *p;
-int ch;
+bothcases(struct parse *p, int ch)
 {
 	char *oldnext = p->next;
 	char *oldend = p->end;
@@ -1055,9 +1033,7 @@ int ch;
  == static void ordinary(struct parse *p, int ch);
  */
 static void
-ordinary(p, ch)
-struct parse *p;
-int ch;
+ordinary(struct parse *p, int ch)
 {
 	cat_t *cap = p->g->categories;
 
@@ -1077,8 +1053,7 @@ int ch;
  * Boy, is this implementation ever a kludge...
  */
 static void
-nonnewline(p)
-struct parse *p;
+nonnewline(struct parse *p)
 {
 	char *oldnext = p->next;
 	char *oldend = p->end;
@@ -1101,11 +1076,10 @@ struct parse *p;
  == static void repeat(struct parse *p, sopno start, int from, int to);
  */
 static void
-repeat(p, start, from, to)
-struct parse *p;
-sopno start;			/* operand from here to end of strip */
-int from;			/* repeated from this number */
-int to;				/* to this number of times (maybe INFINITY) */
+repeat(struct parse *p,
+       sopno start, /* operand from here to end of strip */
+       int from, /* repeated from this number */
+       int to /* to this number of times (maybe INFINITY) */)
 {
 	sopno finish = HERE();
 #	define	N	2
@@ -1173,9 +1147,7 @@ int to;				/* to this number of times (maybe INFINITY) */
  == static int seterr(struct parse *p, int e);
  */
 static int			/* useless but makes type checking happy */
-seterr(p, e)
-struct parse *p;
-int e;
+seterr(struct parse *p, int e)
 {
 	if (p->error == 0)	/* keep earliest error condition */
 		p->error = e;
@@ -1189,8 +1161,7 @@ int e;
  == static cset *allocset(struct parse *p);
  */
 static cset *
-allocset(p)
-struct parse *p;
+allocset(struct parse *p)
 {
 	int no = p->g->ncsets++;
 	size_t nc;
@@ -1244,9 +1215,7 @@ struct parse *p;
  == static void freeset(struct parse *p, cset *cs);
  */
 static void
-freeset(p, cs)
-struct parse *p;
-cset *cs;
+freeset(struct parse *p, cset *cs)
 {
 	int i;
 	cset *top = &p->g->sets[p->g->ncsets];
@@ -1269,9 +1238,7 @@ cset *cs;
  * the same value!
  */
 static int			/* set number */
-freezeset(p, cs)
-struct parse *p;
-cset *cs;
+freezeset(struct parse *p, cset *cs)
 {
 	short h = cs->hash;
 	int i;
@@ -1303,9 +1270,7 @@ cset *cs;
  == static int firstch(struct parse *p, cset *cs);
  */
 static int			/* character; there is no "none" value */
-firstch(p, cs)
-struct parse *p;
-cset *cs;
+firstch(struct parse *p, cset *cs)
 {
 	int i;
 	size_t css = (size_t)p->g->csetsize;
@@ -1322,9 +1287,7 @@ cset *cs;
  == static int nch(struct parse *p, cset *cs);
  */
 static int
-nch(p, cs)
-struct parse *p;
-cset *cs;
+nch(struct parse *p, cset *cs)
 {
 	int i;
 	size_t css = (size_t)p->g->csetsize;
@@ -1343,10 +1306,7 @@ cset *cs;
  ==	char *cp);
  */
 static void
-mcadd(p, cs, cp)
-struct parse *p;
-cset *cs;
-char *cp;
+mcadd(struct parse *p, cset *cs, char *cp)
 {
 	size_t oldend = cs->smultis;
 
@@ -1369,9 +1329,7 @@ char *cp;
  == static void mcsub(cset *cs, char *cp);
  */
 static void
-mcsub(cs, cp)
-cset *cs;
-char *cp;
+mcsub(cset *cs, char *cp)
 {
 	char *fp = mcfind(cs, cp);
 	size_t len = strlen(fp);
@@ -1396,9 +1354,7 @@ char *cp;
  == static int mcin(cset *cs, char *cp);
  */
 static int
-mcin(cs, cp)
-cset *cs;
-char *cp;
+mcin(cset *cs, char *cp)
 {
 	return(mcfind(cs, cp) != NULL);
 }
@@ -1408,9 +1364,7 @@ char *cp;
  == static char *mcfind(cset *cs, char *cp);
  */
 static char *
-mcfind(cs, cp)
-cset *cs;
-char *cp;
+mcfind(cset *cs, char *cp)
 {
 	char *p;
 
@@ -1431,9 +1385,7 @@ char *cp;
  * is deferred.
  */
 static void
-mcinvert(p, cs)
-struct parse *p;
-cset *cs;
+mcinvert(struct parse *p, cset *cs)
 {
 	assert(cs->multis == NULL);	/* xxx */
 }
@@ -1446,9 +1398,7 @@ cset *cs;
  * is deferred.
  */
 static void
-mccase(p, cs)
-struct parse *p;
-cset *cs;
+mccase(struct parse *p, cset *cs)
 {
 	assert(cs->multis == NULL);	/* xxx */
 }
@@ -1458,9 +1408,7 @@ cset *cs;
  == static int isinsets(struct re_guts *g, int c);
  */
 static int			/* predicate */
-isinsets(g, c)
-struct re_guts *g;
-int c;
+isinsets(struct re_guts *g, int c)
 {
 	uch *col;
 	int i;
@@ -1478,10 +1426,7 @@ int c;
  == static int samesets(struct re_guts *g, int c1, int c2);
  */
 static int			/* predicate */
-samesets(g, c1, c2)
-struct re_guts *g;
-int c1;
-int c2;
+samesets(struct re_guts *g, int c1, int c2)
 {
 	uch *col;
 	int i;
@@ -1500,9 +1445,7 @@ int c2;
  == static void categorize(struct parse *p, struct re_guts *g);
  */
 static void
-categorize(p, g)
-struct parse *p;
-struct re_guts *g;
+categorize(struct parse *p, struct re_guts *g)
 {
 	cat_t *cats = g->categories;
 	int c;
@@ -1528,10 +1471,9 @@ struct re_guts *g;
  == static sopno dupl(struct parse *p, sopno start, sopno finish);
  */
 static sopno			/* start of duplicate */
-dupl(p, start, finish)
-struct parse *p;
-sopno start;			/* from here */
-sopno finish;			/* to this less one */
+dupl(struct parse *p,
+     sopno start, /* from here */
+     sopno finish /* to this less one */)
 {
 	sopno ret = HERE();
 	sopno len = finish - start;
@@ -1556,10 +1498,7 @@ sopno finish;			/* to this less one */
  * some changes to the data structures.  Maybe later.
  */
 static void
-doemit(p, op, opnd)
-struct parse *p;
-sop op;
-size_t opnd;
+doemit(struct parse *p, sop op, size_t opnd)
 {
 	/* avoid making error situations worse */
 	if (p->error != 0)
@@ -1582,11 +1521,7 @@ size_t opnd;
  == static void doinsert(struct parse *p, sop op, size_t opnd, sopno pos);
  */
 static void
-doinsert(p, op, opnd, pos)
-struct parse *p;
-sop op;
-size_t opnd;
-sopno pos;
+doinsert(struct parse *p, sop op, size_t opnd, sopno pos)
 {
 	sopno sn;
 	sop s;
@@ -1622,10 +1557,7 @@ sopno pos;
  == static void dofwd(struct parse *p, sopno pos, sop value);
  */
 static void
-dofwd(p, pos, value)
-struct parse *p;
-sopno pos;
-sop value;
+dofwd(struct parse *p, sopno pos, sop value)
 {
 	/* avoid making error situations worse */
 	if (p->error != 0)
@@ -1640,9 +1572,7 @@ sop value;
  == static void enlarge(struct parse *p, sopno size);
  */
 static void
-enlarge(p, size)
-struct parse *p;
-sopno size;
+enlarge(struct parse *p, sopno size)
 {
 	sop *sp;
 
@@ -1663,9 +1593,7 @@ sopno size;
  == static void stripsnug(struct parse *p, struct re_guts *g);
  */
 static void
-stripsnug(p, g)
-struct parse *p;
-struct re_guts *g;
+stripsnug(struct parse *p, struct re_guts *g)
 {
 	g->nstates = p->slen;
 	g->strip = (sop *)realloc((char *)p->strip, p->slen * sizeof(sop));
@@ -1686,9 +1614,7 @@ struct re_guts *g;
  * Note that must and mlen got initialized during setup.
  */
 static void
-findmust(p, g)
-struct parse *p;
-struct re_guts *g;
+findmust(struct parse *p, struct re_guts *g)
 {
 	sop *scan;
 	sop *start = NULL;
@@ -1855,10 +1781,7 @@ struct re_guts *g;
  * re paths.
  */
 static int
-altoffset(scan, offset, mccs)
-sop *scan;
-int offset;
-int mccs;
+altoffset(sop *scan, int offset, int mccs)
 {
 	int largest;
 	int try;
@@ -1937,9 +1860,7 @@ int mccs;
  * the value of the character from the text that was mismatched.
  */
 static void
-computejumps(p, g)
-struct parse *p;
-struct re_guts *g;
+computejumps(struct parse *p, struct re_guts *g)
 {
 	int ch;
 	int mindex;
@@ -1983,9 +1904,7 @@ struct re_guts *g;
  * the search algorithm works.
  */
 static void
-computematchjumps(p, g)
-struct parse *p;
-struct re_guts *g;
+computematchjumps(struct parse *p, struct re_guts *g)
 {
 	int mindex;		/* General "must" iterator */
 	int suffix;		/* Keeps track of matching suffix */
@@ -2059,9 +1978,7 @@ struct re_guts *g;
  == static sopno pluscount(struct parse *p, struct re_guts *g);
  */
 static sopno			/* nesting depth */
-pluscount(p, g)
-struct parse *p;
-struct re_guts *g;
+pluscount(struct parse *p, struct re_guts *g)
 {
 	sop *scan;
 	sop s;

--- a/regex/regerror.c
+++ b/regex/regerror.c
@@ -112,11 +112,8 @@ static struct rerr {
  */
 /* ARGSUSED */
 size_t
-regerror(errcode, preg, errbuf, errbuf_size)
-int errcode;
-const regex_t *__restrict preg;
-char *__restrict errbuf;
-size_t errbuf_size;
+regerror(int errcode, const regex_t *__restrict preg, char *__restrict errbuf,
+		size_t errbuf_size)
 {
 	struct rerr *r;
 	size_t len;
@@ -160,9 +157,7 @@ size_t errbuf_size;
  == static char *regatoi(const regex_t *preg, char *localbuf);
  */
 static char *
-regatoi(preg, localbuf)
-const regex_t *preg;
-char *localbuf;
+regatoi(const regex_t *preg, char *localbuf)
 {
 	struct rerr *r;
 

--- a/regex/regexec.c
+++ b/regex/regexec.c
@@ -154,12 +154,8 @@ static int nope = 0;		/* for use in asserts; shuts lint up */
  * have been prototyped.
  */
 int				/* 0 success, REG_NOMATCH failure */
-regexec(preg, string, nmatch, pmatch, eflags)
-const regex_t *__restrict preg;
-const char *__restrict string;
-size_t nmatch;
-regmatch_t pmatch[__restrict];
-int eflags;
+regexec(const regex_t *__restrict preg, const char *__restrict string,
+		size_t nmatch, regmatch_t pmatch[__restrict], int eflags)
 {
 	struct re_guts *g = preg->re_g;
 #ifdef REDEBUG

--- a/regex/regfree.c
+++ b/regex/regfree.c
@@ -54,8 +54,7 @@ static char sccsid[] = "@(#)regfree.c	8.3 (Berkeley) 3/20/94";
  = extern void regfree(regex_t *);
  */
 void
-regfree(preg)
-regex_t *preg;
+regfree(regex_t *preg)
 {
 	struct re_guts *g;
 


### PR DESCRIPTION
We use a regex implementation from one of BSD's, and it contains old-style definitions which are being slowly dropped from newer compilers.

JIRA: RTOS-1233

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
