### PR TITLE
Add destroy_dev() function as a counterpart to create_dev()

### DIFF
--- a/common/util.h
+++ b/common/util.h
@@ -1,0 +1,28 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * Common libphoenix utilities
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Julian Uziembło
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIBPHOENIX_COMMON_UTIL_H_
+#define _LIBPHOENIX_COMMON_UTIL_H_
+
+#include <stdlib.h>
+#include <string.h>
+
+
+/* 0 if str is NULL, else length + 1 to account for terminator byte */
+static inline size_t __strSizeNull(const char *str)
+{
+	return (str == NULL) ? 0 : (strlen(str) + 1);
+}
+
+
+#endif /* _LIBPHOENIX_COMMON_UTIL_H_ */

--- a/include/posix/utils.h
+++ b/include/posix/utils.h
@@ -16,6 +16,7 @@
 #ifndef _LIBPHOENIX_POSIX_UTILS_H_
 #define _LIBPHOENIX_POSIX_UTILS_H_
 
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/posix/utils.h
+++ b/include/posix/utils.h
@@ -25,6 +25,9 @@ extern "C" {
 extern int create_dev(oid_t *oid, const char *path);
 
 
+extern int destroy_dev(const char *path);
+
+
 extern void splitname(char *path, char **base, char **dir);
 
 

--- a/include/sys/msg.h
+++ b/include/sys/msg.h
@@ -35,6 +35,8 @@ extern void portDestroy(uint32_t port);
 
 extern int portRegister(uint32_t port, const char *name, oid_t *oid);
 
+extern int portUnregister(const char *name);
+
 extern int lookup(const char *name, oid_t *file, oid_t *dev);
 
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -5,4 +5,4 @@
 #
 
 OBJS += $(addprefix $(PREFIX_O)sys/, events.o ioctl.o list.o mount.o rb.o resource.o select.o \
-semaphore.o socket.o stat.o statvfs.o threads.o time.o times.o wait.o uio.o proto.o mman.o uname.o perf.o)
+semaphore.o socket.o stat.o statvfs.o threads.o time.o times.o wait.o uio.o proto.o mman.o uname.o perf.o msg.o)

--- a/sys/msg.c
+++ b/sys/msg.c
@@ -1,0 +1,31 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libphoenix
+ *
+ * sys/msg
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Julian Uziembło
+ *
+ * %LICENSE%
+ */
+
+#include "../common/util.h"
+
+
+extern int sys_portRegister(uint32_t port, const char *name, size_t len, oid_t *oid);
+
+extern int sys_portUnregister(const char *name, size_t len);
+
+
+int portRegister(uint32_t port, const char *name, oid_t *oid)
+{
+	return sys_portRegister(port, name, __strSizeNull(name), oid);
+}
+
+
+int portUnregister(const char *name)
+{
+	return sys_portUnregister(name, __strSizeNull(name));
+}

--- a/unistd/file.c
+++ b/unistd/file.c
@@ -634,25 +634,42 @@ int destroy_dev(const char *path)
 
 	oid_t oid, odev;
 	int retry = 0, err;
-	char *canonical_path, *dir, *sep;
+	char *canonical_path, *dir, *sep, *tpathalloc = NULL;
+	const char *tpath = path;
 
 	if (path == NULL) {
 		return -EINVAL;
 	}
 
 	while (lookup("devfs", NULL, &odev) < 0) {
-		if (++retry < 3 || nodevfs != 0) {
+		/* if destroy_dev() is called by anyone started from syspage devfs
+		 * may be not registered yet so we try 3 times until we give up */
+		if (++retry > 3 || nodevfs != 0) {
 			nodevfs = 1;
 
 			if (lookup("/dev", NULL, &odev) < 0) {
-				return -ENOSYS;
-			}
-			else {
-				break;
-			}
-		}
+				/* Looks like we don't have a filesystem.
+				 * Fall back to portUnregister. */
+				if (*path != '/') {
+					/* Move point to /dev */
+					tpathalloc = malloc(strlen(path) + 6);
+					if (tpathalloc == NULL) {
+						return -ENOMEM;
+					}
+					strcpy(tpathalloc, "/dev/");
+					strcpy(tpathalloc + 5, path);
+					tpath = tpathalloc;
+				}
 
-		usleep(100000);
+				err = portUnregister(tpath);
+				free(tpathalloc);
+				return err;
+			}
+			break;
+		}
+		else {
+			usleep(100000);
+		}
 	}
 
 	if (strncmp("/dev/", path, 5) == 0) {

--- a/unistd/file.c
+++ b/unistd/file.c
@@ -628,6 +628,111 @@ int create_dev(oid_t *oid, const char *path)
 }
 
 
+int destroy_dev(const char *path)
+{
+	static int nodevfs = 0;
+
+	oid_t oid, odev;
+	int retry = 0, err;
+	char *canonical_path, *dir, *sep;
+
+	if (path == NULL) {
+		return -EINVAL;
+	}
+
+	while (lookup("devfs", NULL, &odev) < 0) {
+		if (++retry < 3 || nodevfs != 0) {
+			nodevfs = 1;
+
+			if (lookup("/dev", NULL, &odev) < 0) {
+				return -ENOSYS;
+			}
+			else {
+				break;
+			}
+		}
+
+		usleep(100000);
+	}
+
+	if (strncmp("/dev/", path, 5) == 0) {
+		canonical_path = strdup(path);
+		if (canonical_path == NULL) {
+			return -ENOMEM;
+		}
+	}
+	else {
+		size_t len = 5 + strlen(path) + 1;
+		canonical_path = malloc(len);
+		if (canonical_path == NULL) {
+			return -ENOMEM;
+		}
+		snprintf(canonical_path, len, "/dev/%s", path);
+	}
+
+	if (lookup(canonical_path, NULL, &oid) < 0) {
+		free(canonical_path);
+		return -ENODEV;
+	}
+
+	dir = canonical_path + 5;
+
+	for (;;) {
+		sep = strchr(dir, '/');
+		if (sep == NULL) {
+			break;
+		}
+		*sep = '\0';
+
+		msg_t msg = {
+			.type = mtLookup,
+			.oid = odev,
+			.i.size = strlen(dir) + 1,
+			.i.data = dir,
+		};
+
+		err = msgSend(odev.port, &msg);
+		if (err < 0) {
+			free(canonical_path);
+			return err;
+		}
+
+		if (msg.o.err >= 0) {
+			odev = msg.o.lookup.dev;
+		}
+		else {
+			free(canonical_path);
+			return msg.o.err;
+		}
+
+		do {
+			sep++;
+		} while (*sep == '/');
+		dir = sep;
+	}
+
+	path = dir;
+
+	msg_t msg = {
+		.type = mtUnlink,
+		.oid = odev,
+		.i.ln.oid = oid,
+		.i.data = path,
+		.i.size = strlen(path) + 1,
+	};
+
+	err = msgSend(odev.port, &msg);
+
+	free(canonical_path);
+
+	if (err < 0) {
+		return err;
+	}
+
+	return msg.o.err;
+}
+
+
 extern int sys_fcntl(int fd, int cmd, unsigned val);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
Depends-On: phoenix-rtos-kernel:julianuziemblo/port-unregister
Depends-On: phoenix-rtos-tests:julianuziemblo/CI-651

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/471
- [x] Tested by hand on: `armv7m7-imxrt117x-evk`, `ia32-generic-qemu`, `armv7a7-imx6ull-evk`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/750
- [ ] I will merge this PR by myself when appropriate.
