### PR TITLE
mktemp: fix invalid pointer arithmetic

### DIFF
--- a/stdlib/mktemp.c
+++ b/stdlib/mktemp.c
@@ -47,12 +47,12 @@ static int __mktemp(char *templt, int suffixlen)
 		return fd;
 	}
 
-	int rand[6];
+	unsigned int rand[6];
 	ssize_t left = sizeof(rand);
 	do {
 		ssize_t err;
 		do {
-			err = read(fd, rand + sizeof(rand) - left, left);
+			err = read(fd, (unsigned char *)rand + sizeof(rand) - left, left);
 		} while ((err < 0) && (errno == -EINTR));
 
 		if (err <= 0) {


### PR DESCRIPTION
TASK: RTOS-1275

<!--- Provide a general summary of your changes in the Title above -->

## Description
In the modified line of code the variable `rand` is of type `int[6]` which decays into `int*` and the `+` operator on `int*` will increment in multiples of `sizeof(int)`, therefore `rand + sizeof(rand)` was not the same as `&rand[6]`, it was actually `&rand[24]`. The only reason it ever worked is that pretty much always the `read` from `/dev/urandom` would read in one go and on the first call `sizeof(rand)` and `left` cancel out.

Additionally, Gemini pointed out that `rand` should probably be unsigned to make sure that `pfcs[rand[i] % (sizeof(pfcs) - 1)]` doesn't end up with a negative index.

## Motivation and Context
Just noticed it while reading the code and decided to fix it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv8m-stm32n6`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
