### PR TITLE
!include/(temios,sockios): transfer TTY and SOCK ioctl group defines to kernel

### DIFF
--- a/include/sys/sockios.h
+++ b/include/sys/sockios.h
@@ -20,8 +20,6 @@
 #include <net/if.h>
 #include <net/route.h>
 
-#define SOCK_IOC_TYPE 'S'
-
 /* Socket configuration controls. */
 #define SIOCGIFNAME    _IOWR(SOCK_IOC_TYPE, 0x10, struct ifreq)                   /* get name of interface with given index */
 #define SIOCGIFCONF    _IOC_NESTED(IOC_INOUT, SOCK_IOC_TYPE, 0x12, struct ifconf) /* get iface list */

--- a/include/termios.h
+++ b/include/termios.h
@@ -186,22 +186,22 @@ struct winsize {
 };
 
 /* ioctls */
-#define TCGETS     _IOR('t', 0x1, struct termios)
-#define TCSETS     _IOW('t', 0x2, struct termios)
-#define TCSETSW    _IOW('t', 0x3, struct termios)
-#define TCSETSF    _IOW('t', 0x4, struct termios)
-#define TCFLSH     _IOV('t', 0x5, int)
-#define TCDRAIN    _IO('t', 0x6)
-#define TCSBRK     _IOV('t', 0x9, int)
-#define TIOCSCTTY  _IOV('t', 0xE, int)
-#define TIOCGPGRP  _IOR('t', 0xF, pid_t)
-#define TIOCSPGRP  _IOW('t', 0x10, pid_t)
-#define TIOCGWINSZ _IOR('t', 0x13, struct winsize)
-#define TIOCSWINSZ _IOW('t', 0x14, struct winsize)
-#define TIOCNOTTY  _IO('t', 0x22)
-#define TIOCGSID   _IOR('t', 0x29, pid_t)
-#define TIOCGHALFD _IOR('t', 0x80, int)
-#define TIOCSHALFD _IOV('t', 0x81, int)
+#define TCGETS     _IOR(TTY_IOC_TYPE, 0x1, struct termios)
+#define TCSETS     _IOW(TTY_IOC_TYPE, 0x2, struct termios)
+#define TCSETSW    _IOW(TTY_IOC_TYPE, 0x3, struct termios)
+#define TCSETSF    _IOW(TTY_IOC_TYPE, 0x4, struct termios)
+#define TCFLSH     _IOV(TTY_IOC_TYPE, 0x5, int)
+#define TCDRAIN    _IO(TTY_IOC_TYPE, 0x6)
+#define TCSBRK     _IOV(TTY_IOC_TYPE, 0x9, int)
+#define TIOCSCTTY  _IOV(TTY_IOC_TYPE, 0xE, int)
+#define TIOCGPGRP  _IOR(TTY_IOC_TYPE, 0xF, pid_t)
+#define TIOCSPGRP  _IOW(TTY_IOC_TYPE, 0x10, pid_t)
+#define TIOCGWINSZ _IOR(TTY_IOC_TYPE, 0x13, struct winsize)
+#define TIOCSWINSZ _IOW(TTY_IOC_TYPE, 0x14, struct winsize)
+#define TIOCNOTTY  _IO(TTY_IOC_TYPE, 0x22)
+#define TIOCGSID   _IOR(TTY_IOC_TYPE, 0x29, pid_t)
+#define TIOCGHALFD _IOR(TTY_IOC_TYPE, 0x80, int)
+#define TIOCSHALFD _IOV(TTY_IOC_TYPE, 0x81, int)
 
 /* tcflush */
 enum { TCIFLUSH,


### PR DESCRIPTION
Fixes: #1435

This is breaking as SOCK_IOC_TYPE was transferred to kernel and TTY_IOC_TYPE was defined in kernel.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/759
    - https://github.com/phoenix-rtos/phoenix-rtos-build/pull/273 *armv8r target doesn't build without this so all tests fail immediatelly* 
- [ ] I will merge this PR by myself when appropriate.
