### PR TITLE
socket: implement `accept()` with `syscalls_sys_accept4`

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -71,7 +71,6 @@ int connect(int socket, const struct sockaddr *address, socklen_t address_len);
 int bind(int socket, const struct sockaddr *address, socklen_t address_len);
 int listen(int socket, int backlog);
 int accept4(int socket, struct sockaddr *address, socklen_t *address_len, int flags);
-int accept(int socket, struct sockaddr *address, socklen_t *address_len);
 ssize_t sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len);
 ssize_t sendmsg(int socket, const struct msghdr *msg, int flags) __attribute__((warning("sendmsg() is not fully supported")));
 ssize_t recvfrom(int socket, void *message, size_t length, int flags, struct sockaddr *src_addr, socklen_t *src_len);
@@ -82,6 +81,12 @@ int getsockopt(int socket, int level, int optname, void *optval, socklen_t *optl
 int setsockopt(int socket, int level, int optname, const void *optval, socklen_t optlen);
 int shutdown(int socket, int how);
 int socketpair(int domain, int type, int protocol, int socket_vector[2]);
+
+
+inline int accept(int socket, struct sockaddr *address, socklen_t *address_len)
+{
+	return accept4(socket, address, address_len, 0);
+}
 
 
 inline ssize_t send(int socket, const void *message, size_t length, int flags)

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -72,10 +72,8 @@ int bind(int socket, const struct sockaddr *address, socklen_t address_len);
 int listen(int socket, int backlog);
 int accept4(int socket, struct sockaddr *address, socklen_t *address_len, int flags);
 int accept(int socket, struct sockaddr *address, socklen_t *address_len);
-ssize_t send(int socket, const void *message, size_t length, int flags);
 ssize_t sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len);
 ssize_t sendmsg(int socket, const struct msghdr *msg, int flags) __attribute__((warning("sendmsg() is not fully supported")));
-ssize_t recv(int socket, void *message, size_t length, int flags);
 ssize_t recvfrom(int socket, void *message, size_t length, int flags, struct sockaddr *src_addr, socklen_t *src_len);
 ssize_t recvmsg(int socket, struct msghdr *msg, int flags) __attribute__((warning("recvmsg() is not fully supported")));
 int getpeername(int socket, struct sockaddr *address, socklen_t *address_len);
@@ -85,6 +83,17 @@ int setsockopt(int socket, int level, int optname, const void *optval, socklen_t
 int shutdown(int socket, int how);
 int socketpair(int domain, int type, int protocol, int socket_vector[2]);
 
+
+inline ssize_t send(int socket, const void *message, size_t length, int flags)
+{
+	return sendto(socket, message, length, flags, NULL, 0);
+}
+
+
+inline ssize_t recv(int socket, void *message, size_t length, int flags)
+{
+	return recvfrom(socket, message, length, flags, NULL, 0);
+}
 
 #ifdef __cplusplus
 }

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -72,10 +72,8 @@ int bind(int socket, const struct sockaddr *address, socklen_t address_len);
 int listen(int socket, int backlog);
 int accept4(int socket, struct sockaddr *address, socklen_t *address_len, int flags);
 int accept(int socket, struct sockaddr *address, socklen_t *address_len);
-ssize_t send(int socket, const void *message, size_t length, int flags);
 ssize_t sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len);
 ssize_t sendmsg(int socket, const struct msghdr *msg, int flags) __attribute__((warning("sendmsg() is not fully supported")));
-ssize_t recv(int socket, void *message, size_t length, int flags);
 ssize_t recvfrom(int socket, void *message, size_t length, int flags, struct sockaddr *src_addr, socklen_t *src_len);
 ssize_t recvmsg(int socket, struct msghdr *msg, int flags) __attribute__((warning("recvmsg() is not fully supported")));
 int getpeername(int socket, struct sockaddr *address, socklen_t *address_len);
@@ -85,6 +83,17 @@ int setsockopt(int socket, int level, int optname, const void *optval, socklen_t
 int shutdown(int socket, int how);
 int socketpair(int domain, int type, int protocol, int socket_vector[2]);
 
+
+inline ssize_t send(int socket, const void *message, size_t length, int flags)
+{
+	return sendto(socket, message, length, flags, NULL, 0);
+}
+
+
+inline ssize_t recv(int socket, void *message, size_t length, int flags)
+{
+	return recvfrom(socket, message, length, flags, NULL, NULL);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/socket.c
+++ b/sys/socket.c
@@ -53,6 +53,11 @@ extern ssize_t sys_sendmsg(int socket, const struct msghdr *msg, int flags);
 
 int h_errno;
 
+/* inline wrappers defined in sys/socket.h */
+extern inline ssize_t send(int socket, const void *message, size_t length, int flags);
+extern inline ssize_t recv(int socket, void *message, size_t length, int flags);
+
+
 static int socksrvcall(msg_t *msg)
 {
 	oid_t oid;
@@ -63,18 +68,6 @@ static int socksrvcall(msg_t *msg)
 	if ((err = msgSend(oid.port, msg)) < 0)
 		return SET_ERRNO(err);
 	return 0;
-}
-
-
-ssize_t send(int socket, const void *message, size_t length, int flags)
-{
-	return sendto(socket, message, length, flags, NULL, 0);
-}
-
-
-ssize_t recv(int socket, void *message, size_t length, int flags)
-{
-	return recvfrom(socket, message, length, flags, NULL, 0);
 }
 
 

--- a/sys/socket.c
+++ b/sys/socket.c
@@ -31,7 +31,6 @@
 #include <ifaddrs.h>
 #include <limits.h>
 
-WRAP_ERRNO_DEF(int, accept, (int socket, struct sockaddr *address, socklen_t *address_len), (socket, address, address_len))
 WRAP_ERRNO_DEF(int, accept4, (int socket, struct sockaddr *address, socklen_t *address_len, int flags), (socket, address, address_len, flags))
 WRAP_ERRNO_DEF(int, bind, (int socket, const struct sockaddr *address, socklen_t address_len), (socket, address, address_len))
 WRAP_ERRNO_DEF(int, connect, (int socket, const struct sockaddr *address, socklen_t address_len), (socket, address, address_len))
@@ -54,6 +53,7 @@ extern ssize_t sys_sendmsg(int socket, const struct msghdr *msg, int flags);
 int h_errno;
 
 /* inline wrappers defined in sys/socket.h */
+extern inline int accept(int socket, struct sockaddr *address, socklen_t *address_len);
 extern inline ssize_t send(int socket, const void *message, size_t length, int flags);
 extern inline ssize_t recv(int socket, void *message, size_t length, int flags);
 


### PR DESCRIPTION
This will allow to deprecate/remove `accept` syscall.

TASK: RTOS-1289

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
