### PR TITLE
unistd/sys.c: fix execle to populate envp from independent va_list

### DIFF
--- a/unistd/sys.c
+++ b/unistd/sys.c
@@ -226,10 +226,15 @@ static char **argv_gather(const char *arg, va_list args)
 		return NULL;
 
 	argv[argc++] = (char *)arg;
+	if (arg == NULL) {
+		return argv;
+	}
 
 	while ((argv[argc++] = va_arg(args, char *)) != NULL) {
 		if (argc == max) {
-			if ((res = realloc(argv, max *= 2)) == NULL) {
+			max *= 2;
+			res = realloc(argv, max * sizeof(char *));
+			if (res == NULL) {
 				free(argv);
 				return NULL;
 			}

--- a/unistd/sys.c
+++ b/unistd/sys.c
@@ -287,6 +287,14 @@ int execle(const char *path, const char *arg, ...)
 
 	va_start(args, arg);
 	argv = argv_gather(arg, args);
+	va_end(args);
+
+	/* reinitialize args as it could have been invalidated by (partial) consumption by argv_gather */
+	va_start(args, arg);
+	const char *p = arg;
+	while (p != NULL) {
+		p = va_arg(args, const char *);
+	}
 	envp = va_arg(args, char **);
 	va_end(args);
 


### PR DESCRIPTION
Previous implementation seemed to make non-portable assumptions about va_list reuse/consumption in the callee. As a result

```
execle("/bin/ls", "ls", "-l", NULL, NULL);
```

would cause `envp` to point to garbage on riscv64.

This change uses fresh va_list to ensure safe access to both handles.

Fixes: phoenix-rtos/phoenix-rtos-project#1457
Fixes: phoenix-rtos/phoenix-rtos-project#1465

JIRA: RTOS-1295

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [X] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/481
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
