### PR TITLE
unistd/alarm: start alarm thread with filled sigmask

### DIFF
--- a/unistd/alarm.c
+++ b/unistd/alarm.c
@@ -21,6 +21,7 @@
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <pthread.h>
+#include <sys/debug.h>
 
 
 static struct {
@@ -40,7 +41,6 @@ static void alarm_thread(void *arg)
 	time_t now;
 	long long int sleep;
 
-	signalMask(0xffffffff, 0xffffffff);
 	mutexLock(alarm_common.lock);
 
 	for (;;) {
@@ -63,13 +63,20 @@ static void alarm_thread(void *arg)
 
 static void alarm_initThread(void)
 {
+	sigset_t mask, orgMask;
 	alarm_common.wakeup = 0;
+
+	/* ensure alarm thread will inherit sigmask with all signals blocked */
+	sigfillset(&mask);
+	pthread_sigmask(SIG_BLOCK, &mask, &orgMask);
 	beginthreadex(alarm_thread, priority(-1), alarm_common.stack, sizeof(alarm_common.stack), NULL, &alarm_common.tid);
+	pthread_sigmask(SIG_SETMASK, &orgMask, NULL);
 }
 
 
 static void alarm_init_once(void)
 {
+	/* FIXME: handle errors from mutexCreate, condCreate and beginthreadex */
 	mutexCreate(&alarm_common.lock);
 	condCreate(&alarm_common.cond);
 	alarm_initThread();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fill alarm thread sigmask through inheritance to ensure no signal can be caught before spawned thread has a chance to set its sigmask. Improve `kill(self)` POSIX-compliance by ensuring alarm thread won't handle the signal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Fixes sporadic CI fails in T.sigprocmas](https://github.com/phoenix-rtos/phoenix-rtos-project/actions/runs/27111407775/job/80010985280#annotation:9:57899), verified by running sigprocmas test in a loop for an hour, before fail happened in a few minutes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
