### PR TITLE
stdio/format: fix printing sign for long double

### DIFF
--- a/stdio/format.c
+++ b/stdio/format.c
@@ -621,7 +621,7 @@ static int format_sprintfScientificForm(struct buffer *buff, struct bigdouble *b
 }
 
 
-static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t flags, int minFieldWidth, int precision, char format)
+static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t flags, int minFieldWidth, int precision, char format, uint8_t msb)
 {
 	struct buffer buff;
 	char sign = 0;
@@ -640,7 +640,7 @@ static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t fla
 	}
 
 	/* check sign */
-	if (((num64 >> 63) & 1) != 0) {
+	if (msb != 0) {
 		sign = '-';
 		d = -d;
 	}
@@ -654,6 +654,7 @@ static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t fla
 		sign = '\0';
 	}
 	num64 = format_u64FromDouble(d);
+	num64 |= ((uint64_t)msb << 63);
 
 	CHECK_FAIL(ret, format_bufferInit(&buff, 2 * precision + 6));
 
@@ -1178,19 +1179,26 @@ int format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 			case 'f':
 			case 'g': {
 #ifndef IO_NO_FLOAT
-				double doubleNumber;
+				long double doubleNumber;
+				uint8_t msb = 0;
+
 				if (fmt == 'g' || fmt == 'G') {
 					flags |= FLAG_NO_TRAILING_ZEROS;
 				}
 				if ((flags & FLAG_LONG_DOUBLE) != 0) {
 					/* NOTE: support for long double is incomplete */
-					doubleNumber = (double)va_arg((args), long double);
+					doubleNumber = va_arg((args), long double);
 				}
 				else {
-					doubleNumber = (double)va_arg((args), double);
+					doubleNumber = (long double)va_arg((args), double);
 				}
 
-				CHECK_FAIL(ret, format_sprintfDouble(ctx, feed, doubleNumber, flags, minFieldWidth, precision, tolower(fmt)));
+				/* preserve sign bit during down-conversion to double */
+				if (__builtin_signbit(doubleNumber) != 0) {
+					msb = 1;
+				}
+
+				CHECK_FAIL(ret, format_sprintfDouble(ctx, feed, (double)doubleNumber, flags, minFieldWidth, precision, tolower(fmt), msb));
 				break;
 #else
 				if ((flags & FLAG_LONG_DOUBLE) != 0) {

--- a/stdio/format.c
+++ b/stdio/format.c
@@ -621,7 +621,7 @@ static int format_sprintfScientificForm(struct buffer *buff, struct bigdouble *b
 }
 
 
-static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t flags, int minFieldWidth, int precision, char format)
+static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t flags, int minFieldWidth, int precision, char format, uint8_t msb)
 {
 	struct buffer buff;
 	char sign = 0;
@@ -640,7 +640,7 @@ static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t fla
 	}
 
 	/* check sign */
-	if (((num64 >> 63) & 1) != 0) {
+	if (msb != 0) {
 		sign = '-';
 		d = -d;
 	}
@@ -654,6 +654,7 @@ static int format_sprintfDouble(void *ctx, feedfunc feed, double d, uint32_t fla
 		sign = '\0';
 	}
 	num64 = format_u64FromDouble(d);
+	num64 |= ((uint64_t)msb << 63);
 
 	CHECK_FAIL(ret, format_bufferInit(&buff, 2 * precision + 6));
 
@@ -1180,19 +1181,29 @@ int format_parse(void *ctx, feedfunc feed, const char *format, va_list args)
 			case 'f':
 			case 'g': {
 #ifndef IO_NO_FLOAT
+				long double longDouble;
 				double doubleNumber;
+				uint8_t msb = 0;
+
 				if (fmt == 'g' || fmt == 'G') {
 					flags |= FLAG_NO_TRAILING_ZEROS;
 				}
 				if ((flags & FLAG_LONG_DOUBLE) != 0) {
 					/* NOTE: support for long double is incomplete */
-					doubleNumber = (double)va_arg((args), long double);
+					longDouble = va_arg((args), long double);
+					if (__builtin_signbit(longDouble) != 0) {
+						msb = 1;
+					}
+					doubleNumber = (double)longDouble;
 				}
 				else {
-					doubleNumber = (double)va_arg((args), double);
+					doubleNumber = va_arg((args), double);
+					if (__builtin_signbit(doubleNumber) != 0) {
+						msb = 1;
+					}
 				}
 
-				CHECK_FAIL(ret, format_sprintfDouble(ctx, feed, doubleNumber, flags, minFieldWidth, precision, tolower(fmt)));
+				CHECK_FAIL(ret, format_sprintfDouble(ctx, feed, doubleNumber, flags, minFieldWidth, precision, tolower(fmt), msb));
 				break;
 #else
 				if ((flags & FLAG_LONG_DOUBLE) != 0) {


### PR DESCRIPTION
JIRA: RTOS-1368

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
When down-converting from long double to double on RISCV, GCC is emitting ```__trunctfdf2()``` which truncates sign bit for special values (NaN, inf). This fix preservers sign bit before down-convertion, and adds it later when needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes phoenix-rtos/phoenix-rtos-project#1007

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
