### PR TITLE
sys/threads: assert on uninitialized mutex/cond handles

### DIFF
--- a/sys/threads.c
+++ b/sys/threads.c
@@ -15,6 +15,11 @@
 
 #include <sys/threads.h>
 #include <errno.h>
+#include <assert.h>
+
+
+/* TODO: expose RESOURCE_ID_MIN from kernel headers */
+#define HANDLE_MIN 1
 
 
 int mutexCreate(handle_t *h)
@@ -28,6 +33,9 @@ int mutexCreate(handle_t *h)
 int mutexLock(handle_t m)
 {
 	int err;
+
+	assert(m >= HANDLE_MIN);
+
 	while ((err = phMutexLock(m)) == -EINTR) ;
 	return err;
 }
@@ -44,6 +52,9 @@ int condCreate(handle_t *h)
 int condWait(handle_t h, handle_t m, time_t timeout)
 {
 	int err, mut_err;
+
+	assert(m >= HANDLE_MIN);
+	assert(h >= HANDLE_MIN);
 
 	err = phCondWait(h, m, timeout);
 
@@ -63,6 +74,9 @@ int mutexLock2(handle_t m1, handle_t m2)
 {
 	int err;
 	int tmp;
+
+	assert(m1 >= HANDLE_MIN);
+	assert(m2 >= HANDLE_MIN);
 
 	if ((err = mutexLock(m1)) < 0)
 		return err;


### PR DESCRIPTION
This is first step in improving detection of uninitialized handles. Adding checks to non DEBUG builds needs to be considered, but requires more care before it can be safely adopted.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`mutexLock` is frequently used without checking return value. If mutex create is not invoked then all `mutexLock` invocations are silently ignored without any sign that locks are never actually held.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: 
  * https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/496
- [ ] I will merge this PR by myself when appropriate.
