### PR TITLE
pthread: add new key to thread's key list

### DIFF
--- a/pthread/pthread.c
+++ b/pthread/pthread.c
@@ -1124,15 +1124,24 @@ int pthread_kill(pthread_t thread, int sig)
 
 int pthread_key_create(pthread_key_t *key, void (*destructor)(void *))
 {
-	int err = 0;
-	*key = malloc(sizeof(__pthread_key_t));
-	if (*key == NULL) {
-		err = ENOMEM;
+	int ret;
+	pthread_key_t localkey;
+
+	localkey = (pthread_key_t)malloc(sizeof(__pthread_key_t));
+	if (localkey == NULL) {
+		return ENOMEM;
 	}
-	else {
-		(*key)->destructor = destructor;
+
+	localkey->destructor = destructor;
+
+	ret = pthread_setspecific(localkey, NULL);
+	if (ret != 0) {
+		free(localkey);
+		return ret;
 	}
-	return err;
+
+	*key = localkey;
+	return 0;
 }
 
 


### PR DESCRIPTION
TASK: RTOS-1375

<!--- Provide a general summary of your changes in the Title above -->
When new key was created, it wasn't added to thread's context, and `pthread_key_delete()` failed.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes phoenix-rtos/phoenix-rtos-project#1642

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
