### PR TITLE
syslog: fix extra newline when writing to stderr

### DIFF
--- a/syslog/syslog.c
+++ b/syslog/syslog.c
@@ -154,9 +154,14 @@ void vsyslog(int priority, const char *format, va_list ap)
 
 	/* output to stderr if logging device is not available */
 	if (syslog_common.logopt & LOG_PERROR || syslog_common.connected == 0 || err < 0) {
-		if (syslog_common.buf[len - 1] != '\n')
+		/* don't include \0 (will be interpreted by klog as new empty line) */
+		size_t write_len = len - prefix_size;
+		if (syslog_common.buf[len - 1] != '\n') {
+			/* always end with \n, we have place for it (overwriting \0) */
 			syslog_common.buf[len] = '\n';
-		write(STDERR_FILENO, syslog_common.buf + prefix_size, len - prefix_size + 1);
+			write_len += 1;
+		}
+		write(STDERR_FILENO, syslog_common.buf + prefix_size, write_len);
 	}
 }
 


### PR DESCRIPTION
if writing to klog - ending `\0` would be interpreted as extra newline string. Remove trailing `\0`, always end with newline character.

TASK: MSH-26

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
