### PR TITLE
!pthread: make PTHREAD_EXPLICIT_SCHED as default

### DIFF
--- a/pthread/pthread.c
+++ b/pthread/pthread.c
@@ -103,7 +103,7 @@ static const pthread_attr_t pthread_attr_default = {
 	.schedpolicy = SCHED_RR,
 	.priority = 4,
 	.detachstate = PTHREAD_CREATE_JOINABLE,
-	.inheritsched = PTHREAD_INHERIT_SCHED,
+	.inheritsched = PTHREAD_EXPLICIT_SCHED,
 	.stacksize = ALIGN(PTHREAD_STACK_MIN, PAGE_SIZE),
 	.guardsize = 0
 };


### PR DESCRIPTION
This reverts the behavior introduced by 732d409 that broke existing applications that assumed PTHREAD_EXPLICIT_SCHED.

POSIX does not actually require PTHREAD_INHERIT_SCHED to be default - it can, like other scheduling attributes, be implementation-defined.

TASK: RTOS-1353

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
