### PR TITLE
sys/select: properly handle timeout

### DIFF
--- a/sys/select.c
+++ b/sys/select.c
@@ -13,119 +13,152 @@
  * %LICENSE%
  */
 
+#include <sys/minmax.h>
 #include <sys/select.h>
 #include <errno.h>
 #include <limits.h>
 #include <poll.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sched.h>
 
+#include "../common/util.h"
+
+/* POSIX requires the maximum timeout in select to be at least 31 days */
+#define POSIX_MAX_TIMEOUT_MS (31LL * 24LL * 60LL * 60LL * 1000LL)
 
 #define SFD_ISSET(i, s) ((s) && FD_ISSET(i, s))
 
 
+/* clang-format off */
 WRAP_ERRNO_DEF(int, poll, (struct pollfd *fds, nfds_t nfds, int timeout_ms), (fds, nfds, timeout_ms))
+/* clang-format on */
 
 
-static int poll_timeout(struct timeval *to)
-{
-	time_t timeout;
-
-	if (to && to->tv_sec < INT_MAX / 1000) {
-		timeout = ((to->tv_usec + 999) / 1000) + to->tv_sec * 1000;
-		if (timeout >= 0 && timeout <= INT_MAX)
-			return timeout;
-	}
-
-	return -1;
-}
+extern int nsleep(time_t *sec, long *nsec, int clockid, int flags);
 
 
 int select(int nfds, fd_set *rd, fd_set *wr, fd_set *ex, struct timeval *to)
 {
 	struct pollfd *pfd;
-	time_t timeout;
+	time_t timeoutMs, sec;
 	size_t i, n;
 	int rv;
+	long nsec;
+	long long requestedTimeoutMs;
 
 	if ((nfds < 0) || (nfds > FD_SETSIZE)) {
-		errno = EINVAL;
-		return -1;
+		return SET_ERRNO(-EINVAL);
 	}
 
-	if ((to != NULL) && ((to->tv_usec < 0) || (to->tv_usec > 999999))) {
-		errno = EINVAL;
-		return -1;
+	if (to == NULL) {
+		requestedTimeoutMs = -1;
+	}
+	else {
+		if (!__timevalValid(to) || to->tv_sec < 0) {
+			return SET_ERRNO(-EINVAL);
+		}
+
+		if (to->tv_sec > POSIX_MAX_TIMEOUT_MS / 1000) {
+			requestedTimeoutMs = POSIX_MAX_TIMEOUT_MS;
+		}
+		else {
+			requestedTimeoutMs = min((((long long)to->tv_usec + 999) / 1000) + ((long long)to->tv_sec * 1000), POSIX_MAX_TIMEOUT_MS);
+		}
 	}
 
-	for (n = i = 0; i < nfds; ++i)
-		if (SFD_ISSET(i, rd) || SFD_ISSET(i, wr) || SFD_ISSET(i, ex))
+	for (n = i = 0; i < nfds; ++i) {
+		if (SFD_ISSET(i, rd) || SFD_ISSET(i, wr) || SFD_ISSET(i, ex)) {
 			++n;
-
-	rv = poll_timeout(to);
-	timeout = rv < 0 ? 0 : (time_t)rv;
+		}
+	}
 
 	if (n == 0) {
-		rv = usleep(timeout);
+		if (to == NULL) {
+			rv = pause();
+		}
+		else {
+			sec = min(to->tv_sec, POSIX_MAX_TIMEOUT_MS / 1000);
+			nsec = to->tv_usec * 1000;
+			if (sec != 0 || nsec != 0) {
+				rv = SET_ERRNO(nsleep(&sec, &nsec, CLOCK_MONOTONIC, 0));
+			}
+			else {
+				rv = 0;
+				sched_yield();
+			}
+		}
 		return rv < 0 ? -1 : 0;
 	}
 
 	pfd = calloc(n, sizeof(*pfd));
-	if (!pfd) {
-		errno = ENOMEM;
-		return -1;
+	if (pfd == NULL) {
+		return SET_ERRNO(-ENOMEM);
 	}
 
 	for (n = i = 0; i < nfds; ++i) {
-		if (!(SFD_ISSET(i, rd) || SFD_ISSET(i, wr) || SFD_ISSET(i, ex)))
+		if (!(SFD_ISSET(i, rd) || SFD_ISSET(i, wr) || SFD_ISSET(i, ex))) {
 			continue;
+		}
 
 		pfd[n].fd = i;
-		if (SFD_ISSET(i, rd))
+		if (SFD_ISSET(i, rd)) {
 			pfd[n].events |= POLLIN_SET;
-		if (SFD_ISSET(i, wr))
+		}
+		if (SFD_ISSET(i, wr)) {
 			pfd[n].events |= POLLOUT_SET;
-		if (SFD_ISSET(i, ex))
+		}
+		if (SFD_ISSET(i, ex)) {
 			pfd[n].events |= POLLEX_SET;
+		}
 		pfd[n].events &= ~POLLIGN_SET;
 		++n;
 	}
 
-	rv = poll(pfd, n, timeout);
+	do {
+		timeoutMs = (requestedTimeoutMs < 0) ? -1 : min(requestedTimeoutMs, INT_MAX);
+		rv = poll(pfd, n, (int)timeoutMs);
+		requestedTimeoutMs -= timeoutMs;
+	} while ((rv == 0) && (requestedTimeoutMs > 0));
 
 	for (i = 0; i < n; ++i) {
 		if ((pfd[i].revents & POLLNVAL) != 0) {
-			rv = -EBADF;
+			rv = SET_ERRNO(-EBADF);
 			break;
 		}
 	}
 
 	if (rv < 0) {
-		if (pfd)
-			free(pfd);
-		return SET_ERRNO(rv);
+		free(pfd);
+		/* errno set by poll */
+		return rv;
 	}
 
-	if (rd)
+	if (rd != NULL) {
 		FD_ZERO(rd);
-	if (wr)
+	}
+	if (wr != NULL) {
 		FD_ZERO(wr);
-	if (ex)
+	}
+	if (ex != NULL) {
 		FD_ZERO(ex);
+	}
 
 	for (i = nfds = 0; i < n; ++i) {
-		if (rd && (pfd[i].revents & (POLLIN_SET)))
+		if (rd != NULL && (pfd[i].revents & POLLIN_SET) != 0) {
 			FD_SET(pfd[i].fd, rd);
-		if (wr && (pfd[i].revents & POLLOUT_SET))
+		}
+		if (wr != NULL && (pfd[i].revents & POLLOUT_SET) != 0) {
 			FD_SET(pfd[i].fd, wr);
-		if (ex && (pfd[i].revents & (POLLEX_SET)))
+		}
+		if (ex != NULL && (pfd[i].revents & POLLEX_SET) != 0) {
 			FD_SET(pfd[i].fd, ex);
-		if (SFD_ISSET(pfd[i].fd, rd) | SFD_ISSET(pfd[i].fd, wr)
-				| SFD_ISSET(pfd[i].fd, ex))
+		}
+		if (SFD_ISSET(pfd[i].fd, rd) | SFD_ISSET(pfd[i].fd, wr) | SFD_ISSET(pfd[i].fd, ex)) {
 			nfds++;
+		}
 	}
 
-	if (pfd)
-		free(pfd);
+	free(pfd);
 	return nfds;
 }

--- a/unistd/pause.c
+++ b/unistd/pause.c
@@ -14,42 +14,12 @@
  */
 
 #include <unistd.h>
-#include <errno.h>
-#include <sys/threads.h>
+#include <signal.h>
 
 
 int pause(void)
 {
-	handle_t cond, lock;
-	int err;
-
-	err = condCreate(&cond);
-	if (err < 0) {
-		return SET_ERRNO(err);
-	}
-
-	err = mutexCreate(&lock);
-	if (err < 0) {
-		resourceDestroy(cond);
-		return SET_ERRNO(err);
-	}
-
-	err = phMutexLock(lock);
-	if (err >= 0) {
-		/* Sleep on a private cond - only signal can wake us up */
-		while (err >= 0) {
-			err = phCondWait(cond, lock, 0);
-		}
-
-		if (err != -EINTR) {
-			/* On EINTR phCondWait does not relock the lock.
-			 * Unlock it manually on other cases */
-			(void)mutexUnlock(lock);
-		}
-	}
-
-	resourceDestroy(cond);
-	resourceDestroy(lock);
-
-	return SET_ERRNO(err);
+	sigset_t mask;
+	(void)sigprocmask(SIG_BLOCK, NULL, &mask);
+	return sigsuspend(&mask);
 }


### PR DESCRIPTION
Some fixes to make `select()` more POSIX-compliant.

Fixes: phoenix-rtos/phoenix-rtos-project#1390
YT: RTOS-1417

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
