### PR TITLE
sys/resource: implement getrlimit/setrlimit

### DIFF
--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -16,6 +16,8 @@
 #ifndef _SYS_RESOURCE_H_
 #define _SYS_RESOURCE_H_
 
+#include <phoenix/limits.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <sys/types.h>
 
@@ -25,16 +27,8 @@ extern "C" {
 #endif
 
 
-#define RLIMIT_CORE 0
-#define RLIMIT_STACK 4096
-#define RLIMIT_NOFILE 65536
-
-
-typedef int rlim_t;
-
-
-enum { RLIM_INFINITY = -1, RUSAGE_CHILDREN = -1 };
-enum { RUSAGE_SELF };
+enum { RUSAGE_SELF,
+	RUSAGE_CHILDREN = -1 };
 
 
 struct rusage {
@@ -43,18 +37,29 @@ struct rusage {
 };
 
 
-struct rlimit {
-	rlim_t rlim_cur;
-	rlim_t rlim_max;
-};
+#define PRIO_PROCESS 0
+#define PRIO_PGRP    1
+#define PRIO_USER    2
 
 
-#define PRIO_PROCESS	0
-#define PRIO_PGRP	1
-#define PRIO_USER	2
+extern int rlimits(limit_target_t target, int resource, struct rlimit *oldLimit, const struct rlimit *newLimit);
 
 
 extern int getrusage(int who, struct rusage *usage);
+
+
+static inline int getrlimit(int resource, struct rlimit *rlp)
+{
+	limit_target_t target = { .kind = limit_target_process, .pid = 0 };
+	return SET_ERRNO(rlimits(target, resource, rlp, NULL));
+}
+
+
+static inline int setrlimit(int resource, const struct rlimit *rlp)
+{
+	limit_target_t target = { .kind = limit_target_process, .pid = 0 };
+	return SET_ERRNO(rlimits(target, resource, NULL, rlp));
+}
 
 
 extern int getrlimit(int resource, struct rlimit *rlp);

--- a/posix/stubs.c
+++ b/posix/stubs.c
@@ -124,18 +124,6 @@ int chroot(const char *path)
 }
 
 
-int getrlimit(int resource, struct rlimit *rlp)
-{
-	return 0;
-}
-
-
-int setrlimit(int resource, const struct rlimit *rlp)
-{
-	return 0;
-}
-
-
 dev_t makedev(unsigned int maj, unsigned int min)
 {
 	return 0;

--- a/sys/resource.c
+++ b/sys/resource.c
@@ -13,6 +13,7 @@
  * %LICENSE%
  */
 
+#include <sys/resource.h>
 #include <sys/minmax.h>
 #include <sys/threads.h>
 #include <errno.h>


### PR DESCRIPTION
TASK: RTOS-1346

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Implement POSIX getrlimit/setrlimit functions, declare a new syscall signature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
POSIX API compliance, Foundation API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/830
- [ ] I will merge this PR by myself when appropriate.
